### PR TITLE
[FIX-782] Update copyright year

### DIFF
--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/CDIComponentRuntimeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/CDIComponentRuntimeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/ConfigValue.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/ConfigValue.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/DmtDataType.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/DmtDataType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/HttpServiceRuntimeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/HttpServiceRuntimeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/JaxRsServiceRuntimeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/JaxRsServiceRuntimeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/RuntimeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/RuntimeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/ServiceComponentRuntimeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/ServiceComponentRuntimeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XAttributeDefDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XAttributeDefDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XAttributeDefType.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XAttributeDefType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleInfoDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleInfoDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleLoggerContextDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XBundleLoggerContextDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XComponentDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XComponentDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XComponentReferenceFilterDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XComponentReferenceFilterDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XConfigurationDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XConfigurationDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XDmtNodeDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XDmtNodeDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XEventDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XEventDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHealthCheckDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHealthCheckDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHealthCheckResultDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHealthCheckResultDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHeapUsageDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHeapUsageDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHttpComponentDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XHttpComponentDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XLogEntryDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XLogEntryDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XMemoryInfoDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XMemoryInfoDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XObjectClassDefDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XObjectClassDefDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XPackageDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XPackageDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XPropertyDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XPropertyDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XReferenceDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XReferenceDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XResultDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XResultDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XRoleDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XRoleDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XSatisfiedReferenceDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XSatisfiedReferenceDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XServiceDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XServiceDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XServiceInfoDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XServiceInfoDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XThreadDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XThreadDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XUnsatisfiedReferenceDTO.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/XUnsatisfiedReferenceDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/dto/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/AgentExtension.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/AgentExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/AgentExtensionName.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/AgentExtensionName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/extension/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/BinaryCodec.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/BinaryCodec.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/RemoteRPC.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/RemoteRPC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/MqttRPC.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/MqttRPC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Message.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Message.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Publisher.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Publisher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Subscriber.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/Mqtt5Subscriber.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/api/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/mqtt/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/socket/SocketRPC.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/socket/SocketRPC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/socket/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/rpc/socket/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/EventListener.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/EventListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/LogEntryListener.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/LogEntryListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/MqttConnection.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/MqttConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/SocketConnection.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/SocketConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/Supervisor.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/Supervisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/package-info.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/supervisor/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent.di/src/main/java/com/osgifx/console/agent/di/DI.java
+++ b/com.osgifx.console.agent.di/src/main/java/com/osgifx/console/agent/di/DI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XComponentAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XComponentAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XConfigurationAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XConfigurationAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XDmtAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XDmtAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XDtoAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XDtoAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XEventAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XEventAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XHcAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XHcAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XHttpAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XHttpAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XJmxAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XJmxAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XLogReaderAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XLogReaderAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XLoggerAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XLoggerAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XMetaTypeAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XMetaTypeAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XPropertyAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XPropertyAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XServiceAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XServiceAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XThreadAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XThreadAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XUserAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XUserAdmin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/di/module/DIModule.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/di/module/DIModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/handler/OSGiEventHandler.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/handler/OSGiEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/handler/OSGiLogListener.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/handler/OSGiLogListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/AgentHelper.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/AgentHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/OSGiCompendiumService.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/OSGiCompendiumService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/Reflect.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/Reflect.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/ThreadFactoryBuilder.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/helper/ThreadFactoryBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/BundleStartTimeCalculator.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/BundleStartTimeCalculator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/ClassloaderLeakDetector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/ClassloaderLeakDetector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/PackageWirings.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/PackageWirings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/ConsoleRedirector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/ConsoleRedirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/GogoRedirector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/GogoRedirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/NullRedirector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/NullRedirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/RedirectInput.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/RedirectInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/RedirectOutput.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/RedirectOutput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/Redirector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/Redirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/Shell.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/Shell.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/SocketRedirector.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/redirector/SocketRedirector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/Activator.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/SocketContext.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/SocketContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/FxConstants.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/FxConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/DataProvider.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/DataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/PackageDTO.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/PackageDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/data/provider/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/SearchFilterDTO.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/SearchFilterDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/SnapshotDTO.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/SnapshotDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/dto/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/BundleActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/BundleActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/ComponentActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/ComponentActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/ConfigurationActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/ConfigurationActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/DataRetrievedEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/DataRetrievedEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/DmtActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/DmtActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/EventReceiveEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/EventReceiveEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/LogReceiveEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/LogReceiveEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/LoggerContextActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/LoggerContextActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/RoleActionEventTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/RoleActionEventTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/TableFilterUpdateTopics.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/TableFilterUpdateTopics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/event/topics/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/executor/Executor.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/executor/Executor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * COPYRIGHT 2021-2025 AMIT KUMAR MONDAL
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/executor/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/executor/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/propertytypes/MainThread.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/propertytypes/MainThread.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/propertytypes/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/propertytypes/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/supervisor/factory/SupervisorFactory.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/supervisor/factory/SupervisorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/supervisor/factory/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/supervisor/factory/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/ConsoleMaskerPane.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/ConsoleMaskerPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/ConsoleStatusBar.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/ConsoleStatusBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/package-info.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/ui/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ConsoleFxApplication.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ConsoleFxApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ConsoleFxStage.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ConsoleFxStage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/FxStarter.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/FxStarter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/FxStartupTracker.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/FxStartupTracker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/AgentConnectedAddon.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/AgentConnectedAddon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/AgentPingAddon.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/AgentPingAddon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/ModifiablePropertyAddon.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/ModifiablePropertyAddon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/WindowResizeDisablerAddon.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/WindowResizeDisablerAddon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/AboutApplicationDialog.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/AboutApplicationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/ConnectToMqttAgentDialog.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/ConnectToMqttAgentDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/ConnectToSocketAgentDialog.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/ConnectToSocketAgentDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/MqttConnectionDialog.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/MqttConnectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/MqttConnectionSettingDTO.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/MqttConnectionSettingDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/SocketConnectionDialog.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/SocketConnectionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/SocketConnectionSettingDTO.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dialog/SocketConnectionSettingDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/AboutApplicationDialogController.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/AboutApplicationDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/MqttConnectionSettingsDialogController.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/MqttConnectionSettingsDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/SocketConnectionSettingsDialogController.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/SocketConnectionSettingsDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/AboutApplicationHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/AboutApplicationHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToLocalAgentHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToLocalAgentHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToMqttAgentHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToMqttAgentHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToSocketAgentHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ConnectToSocketAgentHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/DisconnectFromAgentHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/DisconnectFromAgentHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ExtensionListMenuContributionHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/ExtensionListMenuContributionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/MqttConnectionPreferenceHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/MqttConnectionPreferenceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/OpenDiagnosticsHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/OpenDiagnosticsHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/RefreshHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/RefreshHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/SocketConnectionPreferenceHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/SocketConnectionPreferenceHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/ConnectionsProvider.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/ConnectionsProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/theme/DefaultTheme.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/theme/DefaultTheme.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ui/ConsoleMaskerPaneProvider.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ui/ConsoleMaskerPaneProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ui/ConsoleStatusBarProvider.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/ui/ConsoleStatusBarProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageBundleDTO.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageBundleDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageDTO.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageEntryDTO.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageEntryDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageExporter.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageHeaders.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageHeaders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageResourceProcessorDTO.java
+++ b/com.osgifx.console.bnd.dp.packager/src/main/java/com/osgifx/console/bnd/dp/packager/DeploymentPackageResourceProcessorDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/manager/RuntimeDataProvider.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/manager/RuntimeDataProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/manager/RuntimeInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/manager/RuntimeInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/BundlesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/BundlesInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ComponentsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ComponentsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ConfigurationsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ConfigurationsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/EventsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/EventsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HealthChecksInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HealthChecksInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HttpComponentsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HttpComponentsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LeaksInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LeaksInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LoggerContextsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LoggerContextsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LogsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LogsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PackagesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PackagesInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PropertiesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PropertiesInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/RolesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/RolesInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ServicesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ServicesInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/SupplierID.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/SupplierID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ThreadsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ThreadsInfoSupplier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.executor/src/main/java/com/osgifx/console/executor/provider/ExecutorProvider.java
+++ b/com.osgifx.console.executor/src/main/java/com/osgifx/console/executor/provider/ExecutorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/CustomExtension.java
+++ b/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/CustomExtension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/MyContextDTO.java
+++ b/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/MyContextDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/MyResultDTO.java
+++ b/com.osgifx.console.extension.agent.tictactoe/src/main/java/com/osgifx/console/ext/agent/custom/MyResultDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameFxController.java
+++ b/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameFxUI.java
+++ b/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameLogic.java
+++ b/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/GameLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/MyContextDTO.java
+++ b/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/MyContextDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/MyResultDTO.java
+++ b/com.osgifx.console.extension.ui.tictactoe/src/main/java/com/osgifx/console/extension/tictactoe/MyResultDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.launcher/src/main/java/com/osgifx/console/lauchner/Launcher.java
+++ b/com.osgifx.console.launcher/src/main/java/com/osgifx/console/lauchner/Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/ContentResizerPane.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/ContentResizerPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/ContentZoomPane.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/ContentZoomPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/package-info.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/containers/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Digraph.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Digraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/DigraphEdgeList.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/DigraphEdgeList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Edge.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Edge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Graph.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Graph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/GraphEdgeList.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/GraphEdgeList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/InvalidEdgeException.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/InvalidEdgeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/InvalidVertexException.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/InvalidVertexException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Vertex.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/Vertex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/package-info.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graph/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartArrow.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartArrow.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartCircularSortedPlacementStrategy.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartCircularSortedPlacementStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdge.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdge.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeBase.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeBase.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeCurve.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeCurve.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeLine.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphEdgeLine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphPanel.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphProperties.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphVertex.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphVertex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphVertexNode.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartGraphVertexNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabel.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabelSource.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabelSource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabelledNode.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartLabelledNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartPlacementStrategy.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartPlacementStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartRandomPlacementStrategy.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartRandomPlacementStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartStylableNode.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartStylableNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartStyleProxy.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/SmartStyleProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesBindings.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesBindings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesJavaFX.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesJavaFX.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesPoint2D.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/UtilitiesPoint2D.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/package-info.java
+++ b/com.osgifx.console.smartgraph/src/main/java/com/osgifx/console/smartgraph/graphview/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/factory/SupervisorFactoryProvider.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/factory/SupervisorFactoryProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/AbstractRpcSupervisor.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/AbstractRpcSupervisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/RpcSupervisor.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/RpcSupervisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/TokenProvider.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/rpc/TokenProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotSupervisor.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotSupervisor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/ArtifactInstaller.java
+++ b/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/ArtifactInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/BatchInstallDialog.java
+++ b/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/BatchInstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/BatchInstallDialogController.java
+++ b/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/dialog/BatchInstallDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/handler/BatchInstallHandler.java
+++ b/com.osgifx.console.ui.batchinstall/src/main/java/com/osgifx/console/ui/batchinstall/handler/BatchInstallHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundleDetailsFxController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundleDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxUI.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/addon/DragAndDropAddon.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/addon/DragAndDropAddon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDTO.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDialog.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDialogController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/dialog/BundleInstallDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleInstallHandler.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleInstallHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleStartHandler.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleStartHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleStopHandler.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleStopHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleUninstallHandler.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/BundleUninstallHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/GenerateObrHandler.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/handler/GenerateObrHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapReq.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapReq.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapReqBuilder.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapReqBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapabilityBuilder.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapabilityBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapabilityImpl.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/CapabilityImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/RequirementBuilder.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/RequirementBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/RequirementImpl.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/RequirementImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceBuilder.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceImpl.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceUtils.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/TypedAttribute.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/TypedAttribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/Version.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/Version.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/VersionRange.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/VersionRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/XMLResourceGenerator.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/obr/bnd/XMLResourceGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxUI.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ReferenceDetailsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ReferenceDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/handler/ComponentDisableHandler.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/handler/ComponentDisableHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/handler/ComponentEnableHandler.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/handler/ComponentEnableHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationEditorFxController.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationEditorFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxUI.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/control/MultipleCardinalityTextControl.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/control/MultipleCardinalityTextControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/control/PeekablePasswordControl.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/control/PeekablePasswordControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/converter/ConfigurationManager.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/converter/ConfigurationManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/dialog/ConfigurationCreateDialog.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/dialog/ConfigurationCreateDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/dialog/ConfigurationDTO.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/dialog/ConfigurationDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/handler/ConfigurationCreateHandler.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/handler/ConfigurationCreateHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/DmtFxController.java
+++ b/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/DmtFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/DmtFxUI.java
+++ b/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/DmtFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/UpdateNodeDialog.java
+++ b/com.osgifx.console.ui.dmt/src/main/java/com/osgifx/console/ui/dmt/UpdateNodeDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/DtoFxController.java
+++ b/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/DtoFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/DtoFxUI.java
+++ b/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/DtoFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventDetailsFxController.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxController.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxUI.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/converter/EventManager.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/converter/EventManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/EventDTO.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/EventDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SendEventDialog.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SendEventDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SubscribedEventsDialog.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SubscribedEventsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SubscribedEventsDialogController.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/SubscribedEventsDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/TopicEntryDialog.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/dialog/TopicEntryDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/ClearEventsTableHandler.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/ClearEventsTableHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/EventReceiveMenuContributionHandler.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/EventReceiveMenuContributionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/SendEventHandler.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/handler/SendEventHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/DeploymentPackageDTO.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/DeploymentPackageDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialog.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialogController.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialogController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/handler/ExtensionInstallHandler.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/handler/ExtensionInstallHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/handler/ExtensionsViewHandler.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/handler/ExtensionsViewHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoConsoleHistory.java
+++ b/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoConsoleHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoFxController.java
+++ b/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoFxUI.java
+++ b/com.osgifx.console.ui.gogo/src/main/java/com/osgifx/console/ui/gogo/GogoFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/BundleVertex.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/BundleVertex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/ComponentVertex.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/ComponentVertex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/FxBundleGraph.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/FxBundleGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/FxComponentGraph.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/FxComponentGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphController.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxBundleController.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxBundleController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxComponentController.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxComponentController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxUI.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphHelper.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeBundleGraph.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeBundleGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeComponentGraph.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeComponentGraph.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.healthchecks/src/main/java/com/osgifx/console/ui/healthchecks/HealthCheckFxController.java
+++ b/com.osgifx.console.ui.healthchecks/src/main/java/com/osgifx/console/ui/healthchecks/HealthCheckFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.healthchecks/src/main/java/com/osgifx/console/ui/healthchecks/HealthCheckFxUI.java
+++ b/com.osgifx.console.ui.healthchecks/src/main/java/com/osgifx/console/ui/healthchecks/HealthCheckFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorChart.java
+++ b/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorChart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorFxUI.java
+++ b/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorPane.java
+++ b/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorPane.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpDetailsFxController.java
+++ b/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
+++ b/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxUI.java
+++ b/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
+++ b/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxUI.java
+++ b/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationEditorFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationEditorFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogDetailsFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsFxUI.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsViewFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsViewFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/StarterFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/StarterFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/dialog/LoggerConfigurationDialog.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/dialog/LoggerConfigurationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/handler/ClearLogsTableHandler.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/handler/ClearLogsTableHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/handler/LogReceiveMenuContributionHandler.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/handler/LogReceiveMenuContributionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/helper/LoggerConfigTextControl.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/helper/LoggerConfigTextControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/helper/LogsHelper.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/helper/LogsHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.overview/src/main/java/com/osgifx/console/ui/overview/OverviewFxUI.java
+++ b/com.osgifx.console.ui.overview/src/main/java/com/osgifx/console/ui/overview/OverviewFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.overview/src/main/java/com/osgifx/console/ui/overview/ViewRefreshDelayDialog.java
+++ b/com.osgifx.console.ui.overview/src/main/java/com/osgifx/console/ui/overview/ViewRefreshDelayDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackageDetailsFxController.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackageDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxUI.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxController.java
+++ b/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxUI.java
+++ b/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RoleEditorFxController.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RoleEditorFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxUI.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/dialog/PropertiesConfigurationDialog.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/dialog/PropertiesConfigurationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/dialog/RoleCreateDialog.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/dialog/RoleCreateDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/handler/RoleCreateHandler.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/handler/RoleCreateHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/helper/RolesConfigTextControl.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/helper/RolesConfigTextControl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/helper/RolesHelper.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/helper/RolesHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/dialog/FilterDTO.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/dialog/FilterDTO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/dialog/SearchDialog.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/dialog/SearchDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchComponent.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchFilter.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchFilterManager.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchFilterManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchOperation.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/SearchOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByActivationPolicy.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByActivationPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByAttachedFragment.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByAttachedFragment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByCategory.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByCategory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByDataFolderSize.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByDataFolderSize.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByExportedPackage.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByExportedPackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByFragment.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByFragment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByHostBundle.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByHostBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByImportedPackage.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByImportedPackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByManifestHeader.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByManifestHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByPersistentStart.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByPersistentStart.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByRegisteredService.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByRegisteredService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByRevision.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByRevision.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByStartDuration.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByStartDuration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByStartLevel.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByStartLevel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByState.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterBySymbolicName.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterBySymbolicName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByUsedService.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByUsedService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByVendor.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByVendor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByVersion.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByWiredBundleAsProvider.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByWiredBundleAsProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByWiredBundleAsRequirer.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/bundle/BundleSearchFilterByWiredBundleAsRequirer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByConfigurationPolicy.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByConfigurationPolicy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByImplementationClass.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByImplementationClass.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByPID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByPID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByProperty.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByReference.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByReference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByRegisteringBundle.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByRegisteringBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByServiceInterface.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByServiceInterface.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByState.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/component/ComponentSearchFilterByState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByFactoryPID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByFactoryPID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByPID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByPID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByProperty.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/configuration/ConfigurationSearchFilterByProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByExporter.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByImporter.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByImporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByName.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByName.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByVersion.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/pkg/PackageFilterByVersion.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByID.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByID.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByProperty.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByRegisteringBundle.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByRegisteringBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByType.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByUsingBundle.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/filter/service/ServiceSearchFilterByUsingBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/handler/SearchHandler.java
+++ b/com.osgifx.console.ui.search/src/main/java/com/osgifx/console/ui/search/handler/SearchHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServiceDetailsFxController.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServiceDetailsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxUI.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.snapshot/src/main/java/com/osgifx/console/ui/snapshot/handler/SnapshotCaptureHandler.java
+++ b/com.osgifx.console.ui.snapshot/src/main/java/com/osgifx/console/ui/snapshot/handler/SnapshotCaptureHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.snapshot/src/main/java/com/osgifx/console/ui/snapshot/handler/SnapshotImportHandler.java
+++ b/com.osgifx.console.ui.snapshot/src/main/java/com/osgifx/console/ui/snapshot/handler/SnapshotImportHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalFxController.java
+++ b/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalFxUI.java
+++ b/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalHistory.java
+++ b/com.osgifx.console.ui.terminal/src/main/java/com/osgifx/console/ui/terminal/TerminalHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
+++ b/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxUI.java
+++ b/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxUI.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/agent/ExtensionHelper.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/agent/ExtensionHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/agent/package-info.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/agent/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/ConfigHelper.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/ConfigHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/FactoryConfigHelper.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/FactoryConfigHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/package-info.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/configuration/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/converter/ValueConverter.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/converter/ValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/converter/package-info.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/converter/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/ConsoleFxHelper.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/ConsoleFxHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/DTOCellValueFactory.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/DTOCellValueFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/Fx.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/Fx.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/FxDialog.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/FxDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/MultipleCardinalityPropertiesDialog.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/MultipleCardinalityPropertiesDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/NullTableViewSelectionModel.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/NullTableViewSelectionModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/PeekablePasswordField.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/PeekablePasswordField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/PropertiesForm.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/PropertiesForm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License.  You may obtain a copy

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/package-info.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/fx/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/io/IO.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/io/IO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/com.osgifx.console.util/src/main/java/com/osgifx/console/util/io/package-info.java
+++ b/com.osgifx.console.util/src/main/java/com/osgifx/console/util/io/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright 2021-2025 Amit Kumar Mondal
+ * Copyright 2021-2026 Amit Kumar Mondal
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
Adjusts the copyright year in all relevant source files from 2025 to 2026.

fixes #782