### PR TITLE
Adds headless agent connection mode

### DIFF
--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/BinaryLogBuffer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/BinaryLogBuffer.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
 package com.osgifx.console.agent.provider;
 
 import java.io.DataInputStream;

--- a/com.osgifx.console.agent/src/test/java/com/osgifx/console/agent/provider/BinaryLogBufferTest.java
+++ b/com.osgifx.console.agent/src/test/java/com/osgifx/console/agent/provider/BinaryLogBufferTest.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
 package com.osgifx.console.agent.provider;
 
 import static org.junit.Assert.assertEquals;

--- a/com.osgifx.console.application/Application.e4xmi
+++ b/com.osgifx.console.application/Application.e4xmi
@@ -82,4 +82,5 @@
   <addons xmi:id="_KtoIsMq7Eey474eteoLOGg" elementId="com.osgifx.console.application.addon.agentconnected" contributionURI="bundleclass://com.osgifx.console.application/com.osgifx.console.application.addon.AgentConnectedAddon"/>
   <addons xmi:id="_i3pw8GCeEe2X6eso_goi0A" elementId="com.osgifx.console.application.addon.lifecycle" contributionURI="bundleclass://org.eclipse.fx.ui.workbench.services/org.eclipse.fx.ui.workbench.services.lifecycle.LifecycleAddon"/>
   <addons xmi:id="_qlcEAGoKEe21Cs8uJesKFQ" elementId="com.osgifx.console.application.addon.window.resize.disabler" contributionURI="bundleclass://com.osgifx.console.application/com.osgifx.console.application.addon.WindowResizeDisablerAddon"/>
+  <addons xmi:id="_newHeadlessLaunchAddonId" elementId="com.osgifx.console.application.addon.headless" contributionURI="bundleclass://com.osgifx.console.application/com.osgifx.console.application.addon.HeadlessLaunchAddon"/>
 </application:Application>

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/HeadlessLaunchAddon.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/addon/HeadlessLaunchAddon.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.addon;
+
+import static com.osgifx.console.supervisor.Supervisor.AGENT_CONNECTED_EVENT_TOPIC;
+import static com.osgifx.console.supervisor.factory.SupervisorFactory.SupervisorType.REMOTE_RPC;
+import static com.osgifx.console.supervisor.factory.SupervisorFactory.SupervisorType.SNAPSHOT;
+
+import java.io.File;
+import java.io.FileReader;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.core.services.events.IEventBroker;
+import org.eclipse.fx.core.di.ContextBoundValue;
+import org.eclipse.fx.core.di.ContextValue;
+import org.eclipse.fx.core.log.FluentLogger;
+import org.eclipse.fx.core.log.Log;
+
+import com.google.gson.Gson;
+import com.osgifx.console.application.dto.HeadlessConfigDTO;
+import com.osgifx.console.application.dto.HeadlessConnectionType;
+import com.osgifx.console.supervisor.MqttConnection;
+import com.osgifx.console.supervisor.SocketConnection;
+import com.osgifx.console.supervisor.Supervisor;
+import com.osgifx.console.supervisor.factory.SupervisorFactory;
+import com.osgifx.console.util.fx.FxDialog;
+
+public final class HeadlessLaunchAddon {
+
+    @Log
+    @Inject
+    private FluentLogger               logger;
+    @Inject
+    private IEventBroker               eventBroker;
+    @Inject
+    @Optional
+    private Supervisor                 supervisor;
+    @Inject
+    private SupervisorFactory          supervisorFactory;
+    @Inject
+    @Optional
+    @ContextValue("headless.config")
+    private HeadlessConfigDTO          headlessConfig;
+    @Inject
+    @Optional
+    @ContextValue("is_connected")
+    private ContextBoundValue<Boolean> isConnected;
+    @Inject
+    @Optional
+    @ContextValue("is_local_agent")
+    private ContextBoundValue<Boolean> isLocalAgent;
+    @Inject
+    @Optional
+    @ContextValue("is_snapshot_agent")
+    private ContextBoundValue<Boolean> isSnapshotAgent;
+    @Inject
+    @Optional
+    @ContextValue("connected.agent")
+    private ContextBoundValue<String>  connectedAgent;
+
+    @PostConstruct
+    public void init() {
+        logger.atInfo().log("HeadlessLaunchAddon initialized");
+        // check if a configuration file is provided for headless launch
+        final var configPath = System.getProperty("osgifx.config");
+        if (configPath != null) {
+            logger.atInfo().log("Headless configuration config path found: %s", configPath);
+            try (var reader = new FileReader(new File(configPath))) {
+                final var gson = new Gson();
+                headlessConfig = gson.fromJson(reader, HeadlessConfigDTO.class);
+                logger.atInfo().log("Headless configuration parsed: %s", headlessConfig);
+            } catch (final Exception e) {
+                logger.atError().withException(e).log("Failed to parse headless configuration");
+                // if parsing fails, log and proceed to show the connection wizard or handle it in the addon
+                e.printStackTrace();
+            }
+        } else {
+            logger.atInfo().log("System property 'osgifx.config' is not set");
+        }
+        if (headlessConfig == null) {
+            logger.atInfo()
+                    .log("No headless configuration found (dependency injection is null and system property is null)");
+            return;
+        }
+        logger.atInfo().log("Headless configuration found: %s", headlessConfig);
+        try {
+            // Remove any existing supervisor (e.g. Snapshot)
+            supervisorFactory.removeSupervisor(SNAPSHOT);
+            supervisorFactory.createSupervisor(REMOTE_RPC);
+
+            if (HeadlessConnectionType.SOCKET == headlessConfig.type) {
+                connectSocket();
+            } else if (HeadlessConnectionType.MQTT == headlessConfig.type) {
+                connectMqtt();
+            } else {
+                logger.atWarning().log("Unknown connection type: %s", headlessConfig.type);
+            }
+        } catch (final Exception e) {
+            logger.atError().withException(e).log("Failed to establish headless connection");
+            FxDialog.showExceptionDialog(e, getClass().getClassLoader());
+        }
+    }
+
+    private void connectSocket() throws Exception {
+        if (headlessConfig.socket == null) {
+            logger.atWarning().log("Socket configuration is missing");
+            return;
+        }
+        // @formatter:off
+        final var socketConnection = SocketConnection
+                .builder()
+                .host(headlessConfig.socket.host)
+                .port(headlessConfig.socket.port)
+                .timeout(headlessConfig.socket.timeout)
+                .truststore(headlessConfig.socket.trustStorePath)
+                .truststorePass(headlessConfig.socket.trustStorePassword)
+                .build();
+        // @formatter:on
+
+        supervisor.connect(socketConnection);
+        logger.atInfo().log("Successfully connected to Socket Agent at %s:%s", headlessConfig.socket.host,
+                headlessConfig.socket.port);
+        broadcastConnection("[SOCKET] " + headlessConfig.socket.host + ":" + headlessConfig.socket.port);
+    }
+
+    private void connectMqtt() throws Exception {
+        if (headlessConfig.mqtt == null) {
+            logger.atWarning().log("MQTT configuration is missing");
+            return;
+        }
+        // @formatter:off
+        final var mqttConnection = MqttConnection
+                .builder()
+                .clientId(headlessConfig.mqtt.clientId)
+                .server(headlessConfig.mqtt.server)
+                .port(headlessConfig.mqtt.port)
+                .timeout(headlessConfig.mqtt.timeout)
+                .username(headlessConfig.mqtt.username)
+                .password(headlessConfig.mqtt.password)
+                .tokenConfig(null) // Token config not yet supported in CLI JSON for simplicity, can be added if needed
+                .pubTopic(headlessConfig.mqtt.pubTopic)
+                .subTopic(headlessConfig.mqtt.subTopic)
+                .lwtTopic(headlessConfig.mqtt.lwtTopic)
+                .build();
+        // @formatter:on
+
+        supervisor.connect(mqttConnection);
+        logger.atInfo().log("Successfully connected to MQTT Agent at %s:%s", headlessConfig.mqtt.server,
+                headlessConfig.mqtt.port);
+        broadcastConnection("[MQTT] " + headlessConfig.mqtt.server + ":" + headlessConfig.mqtt.port);
+    }
+
+    private void broadcastConnection(final String connectionString) {
+        eventBroker.post(AGENT_CONNECTED_EVENT_TOPIC, connectionString);
+        connectedAgent.publish(connectionString);
+        isConnected.publish(true);
+        isLocalAgent.publish(false);
+        isSnapshotAgent.publish(false);
+    }
+}

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/HeadlessConfigDTO.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/HeadlessConfigDTO.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class HeadlessConfigDTO {
+
+    public HeadlessConnectionType type;
+    public SocketConfigDTO        socket;
+    public MqttConfigDTO          mqtt;
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
+    }
+
+}

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/HeadlessConnectionType.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/HeadlessConnectionType.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.dto;
+
+public enum HeadlessConnectionType {
+    SOCKET,
+    MQTT
+}

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/MqttConfigDTO.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/MqttConfigDTO.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class MqttConfigDTO {
+
+    public String server;
+    public int    port;
+    public int    timeout;
+    public String clientId;
+    public String username;
+    public String password;
+    public String pubTopic;
+    public String subTopic;
+    public String lwtTopic;
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
+    }
+}

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/SocketConfigDTO.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/dto/SocketConfigDTO.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.dto;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public class SocketConfigDTO {
+
+    public String host;
+    public int    port;
+    public int    timeout;
+    public String trustStorePath;
+    public String trustStorePassword;
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this, ToStringStyle.JSON_STYLE);
+    }
+}

--- a/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/FilterableTreeItem.java
+++ b/com.osgifx.console.ui.dto/src/main/java/com/osgifx/console/ui/dto/FilterableTreeItem.java
@@ -1,3 +1,18 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
 package com.osgifx.console.ui.dto;
 
 import org.eclipse.fx.ui.controls.tree.TreeItemComparator;


### PR DESCRIPTION
Introduces a headless launch addon enabling automatic connection to OSGi agents without a UI.

The application can now parse connection details from a JSON configuration file, specified by the `osgifx.config` system property. This supports both Socket and MQTT connection types, facilitating automation for scripting or CI/CD environments. Dedicated DTOs are included to structure the headless configuration.

Also adds missing license headers to several files.

fixes #798