### PR TITLE
Implements Streamable HTTP transport

### DIFF
--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpHttpServer.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpHttpServer.java
@@ -68,13 +68,16 @@ public class McpHttpServer {
 
     private HTTPServer httpServer;
 
-    // Tracks active SSE connections (useful for cleanup or future notifications)
-    private final Map<Object, Boolean> activeConnections = new ConcurrentHashMap<>();
+    // Tracks active SSE connections (locks mapped to response objects)
+    // We use the lock object as key, and handle the response writing carefully.
+    private final Map<Object, HTTPResponse> activeSseResponses = new ConcurrentHashMap<>();
 
     @Activate
     void activate(final Configuration config) {
         logger = FluentLogger.of(factory.createLogger(getClass().getName()));
         startServer(config);
+        // Register notification sender to broadcast to all SSE clients
+        mcpProvider.getServer().setNotificationSender(this::broadcast);
     }
 
     @Deactivate
@@ -92,18 +95,22 @@ public class McpHttpServer {
             final String path = req.getPath();
             logger.atInfo().log("Incoming Request: %s %s", req.getMethod(), path);
 
-            // SSE Endpoint (GET /sse) - Handshake
-            if (("/sse".equals(path) || path.startsWith("/sse?")) && HTTPMethod.GET == req.getMethod()) {
-                handleSseConnection(req, res);
-                return;
-            }
+            // Streamable HTTP Endpoint (GET/POST /mcp)
+            if ("/mcp".equals(path) || path.startsWith("/mcp?")) {
+                // Handle Preflight OPTIONS request for CORS (if needed later)
+                // For now, implementing standard interactions.
 
-            // Message Endpoint (POST /messages OR POST /sse)
-            final boolean isMessagePath = "/messages".equals(path) || path.startsWith("/messages?")
-                    || "/sse".equals(path) || path.startsWith("/sse?");
-            if (isMessagePath && HTTPMethod.POST == req.getMethod()) {
-                handleMessage(req, res);
-                return;
+                // POST: Message Handling (Stateless)
+                if (HTTPMethod.POST == req.getMethod()) {
+                    handleMessage(req, res);
+                    return;
+                }
+
+                // GET: Optional SSE Streaming
+                if (HTTPMethod.GET == req.getMethod() && "text/event-stream".equals(req.getHeader("Accept"))) {
+                    handleSseConnection(req, res);
+                    return;
+                }
             }
 
             logger.atError().log("404 Not Found: %s %s", req.getMethod(), path);
@@ -115,7 +122,7 @@ public class McpHttpServer {
         httpServer = new HTTPServer().withListener(listenerConfig).withHandler(handler);
         httpServer.start();
 
-        logger.atInfo().log("MCP HTTP Server started at http://localhost:%d/sse", config.port());
+        logger.atInfo().log("MCP HTTP Server started at http://localhost:%d/mcp", config.port());
     }
 
     private void stopServer() {
@@ -124,31 +131,79 @@ public class McpHttpServer {
             httpServer = null;
         }
         // Release any blocked threads waiting on SSE connections
-        synchronized (activeConnections) {
-            activeConnections.notifyAll();
+        synchronized (activeSseResponses) {
+            activeSseResponses.keySet().forEach(lock -> {
+                synchronized (lock) {
+                    lock.notifyAll();
+                }
+            });
         }
         logger.atInfo().log("MCP HTTP Server stopped");
     }
 
+    /**
+     * Broadcasts a message to all active SSE connections.
+     *
+     * @param message The JSON-RPC message to send.
+     */
+    private void broadcast(final String message) {
+        // Format as SSE event: name 'message'
+        final String sseData = "event: message\ndata: " + message + "\n\n";
+        final byte[] bytes   = sseData.getBytes(StandardCharsets.UTF_8);
+
+        // Iterate safely over active connections
+        activeSseResponses.values().forEach(res -> {
+            try {
+                // Note: Writing to the output stream from a different thread while the handlers
+                // are blocked might require the underlying server to support concurrent IO.
+                // FusionAuth HTTP server's response output stream should be thread-safe for writing.
+                res.getOutputStream().write(bytes);
+                res.flush();
+            } catch (final IOException e) {
+                logger.atWarning().withException(e).log("Failed to broadcast to SSE client");
+                // We cannot remove the client here easily as it's managed by the handler thread lock.
+                // The handler thread will likely exit if writing fails eventually.
+            }
+        });
+    }
+
     private void handleSseConnection(final HTTPRequest req, final HTTPResponse res) {
         try {
+            // Log Streamable HTTP headers for debugging/context
+            String sessionId   = req.getHeader("Mcp-Session-Id");
+            String lastEventId = req.getHeader("Last-Event-ID");
+            logger.atDebug().log("SSE Connection Request - Session: %s, Last-Event-ID: %s", sessionId, lastEventId);
+
             // Standard SSE Headers
             res.setHeader("Content-Type", "text/event-stream");
             res.setHeader("Cache-Control", "no-cache");
             res.setHeader("Connection", "keep-alive");
-            res.setStatus(200);
 
-            // CRITICAL: Send the 'endpoint' event immediately.
-            // This tells the AI client: "I am ready. Send POST requests to /messages"
-            // Therefore, generate a session ID to satisfy clients that require it.
-            final String sessionId = UUID.randomUUID().toString();
-            final String initEvent = "event: endpoint\ndata: /messages?sessionId=" + sessionId + "\n\n";
-            res.getOutputStream().write(initEvent.getBytes(StandardCharsets.UTF_8));
-            res.flush();
+            // Reflect Protocol Version if requested
+            String protocolVersion = req.getHeader("MCP-Protocol-Version");
+            if (protocolVersion != null) {
+                res.setHeader("MCP-Protocol-Version", protocolVersion); // Or negotiate supported version
+            }
+
+            // If Session ID is missing, we could generate one (optional in new spec for stateless,
+            // but good for tracking if we add state later).
+            if (sessionId == null) {
+                sessionId = UUID.randomUUID().toString();
+                // In Streamable HTTP, we might want to return this, but SSE is a stream.
+                // We can't easily validly set a response header for the *stream* if headers are already flushed?
+                // But strictly, we haven't flushed yet.
+                res.setHeader("Mcp-Session-Id", sessionId);
+            }
+
+            res.setStatus(200);
+            res.flush(); // Send headers
+
+            // In Streamable HTTP, we don't need to send the 'endpoint' handshake event.
+            // We just keep the connection open for any potential server-initiated notifications.
 
             // Keep connection open by blocking
             final Object connectionLock = new Object();
-            activeConnections.put(connectionLock, Boolean.TRUE);
+            activeSseResponses.put(connectionLock, res);
 
             try {
                 synchronized (connectionLock) {
@@ -158,7 +213,7 @@ public class McpHttpServer {
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
             } finally {
-                activeConnections.remove(connectionLock);
+                activeSseResponses.remove(connectionLock);
             }
         } catch (final IOException e) {
             // Client likely disconnected, which is normal behavior
@@ -168,9 +223,18 @@ public class McpHttpServer {
 
     private void handleMessage(final HTTPRequest req, final HTTPResponse res) {
         try {
+            // Log session context
+            String sessionId = req.getHeader("Mcp-Session-Id");
+            logger.atDebug().log("MCP Message - Session: %s", sessionId);
+
             // Read the JSON body
-            // Note: FusionAuth doesn't auto-parse body, so read all bytes
             final String body = new String(req.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+
+            // Generate Session ID if missing (especially on 'initialize')
+            if (sessionId == null && body.contains("\"method\":\"initialize\"")) { // Simple check, ideally parse JSON
+                sessionId = UUID.randomUUID().toString();
+                logger.atDebug().log("Generated new session ID for initialization: %s", sessionId);
+            }
 
             // Delegate to the MCP JSON-RPC Server
             final String responseJson = mcpProvider.getServer().handleMessage(body);
@@ -178,11 +242,23 @@ public class McpHttpServer {
             // Send the response
             if (responseJson != null) {
                 res.setHeader("Content-Type", "application/json");
+                // Reflect session ID if present/generated?
+                // Spec says server SHOULD echo it if it generated it, but usually client sends it.
+                if (sessionId != null) {
+                    res.setHeader("Mcp-Session-Id", sessionId);
+                }
+
+                // Reflect Protocol Version if requested
+                String protocolVersion = req.getHeader("MCP-Protocol-Version");
+                if (protocolVersion != null) {
+                    res.setHeader("MCP-Protocol-Version", protocolVersion);
+                }
+
                 res.setStatus(200);
                 res.getOutputStream().write(responseJson.getBytes(StandardCharsets.UTF_8));
             } else {
-                // If it was a notification, return 204 No Content
-                res.setStatus(204);
+                // If it was a notification, return 202 Accepted (per spec)
+                res.setStatus(202);
             }
         } catch (final Exception e) {
             logger.atError().withException(e).log("Error handling MCP message");

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpServerProvider.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpServerProvider.java
@@ -83,7 +83,7 @@ public class McpServerProvider {
         logger = FluentLogger.of(factory.createLogger(getClass().getName()));
         logger.atInfo().log("MCP server has been started successfully");
     }
-    
+
     @Deactivate
     void deactivate() {
         logger.atInfo().log("MCP server has been stopped successfully");


### PR DESCRIPTION
Unifies HTTP endpoints under '/mcp' for both message handling (POST) and server-sent events (GET). Establishes a mechanism for the JSON-RPC server to send notifications to connected SSE clients. Broadcasts 'notifications/tools/list_changed' when tools are added or removed. Aligns SSE and message request/response handling with Streamable HTTP specifications, including session ID propagation, protocol version headers, and using HTTP 202 for notifications. Removes the explicit 'endpoint' handshake event from SSE connections.

fixes #804