### PR TITLE
Documented headless launch configuration

### DIFF
--- a/HEADLESS_LAUNCH.md
+++ b/HEADLESS_LAUNCH.md
@@ -1,0 +1,74 @@
+# Headless Launch Configuration
+
+**OSGi.fx** supports a "Headless" launch mode, which allows you to start the application with a pre-defined connection configuration. This skips the initial connection wizard and automatically connects to the configured agent.
+
+> [!NOTE]
+> "Headless" in this context means "without the connection wizard UI", not necessarily without any UI at all. The main application window will still open after connection.
+
+## How to Use
+
+To use this feature, you need to provide a JSON configuration file via the `osgifx.config` system property when launching the application.
+
+```bash
+java -Dosgifx.config=/path/to/config.json -jar osgifx.jar
+```
+
+## Configuration Format
+
+The configuration file must be a valid JSON file. You can configure either a **Socket** connection or an **MQTT** connection.
+
+### Socket Connection Example
+
+```json
+{
+  "type": "SOCKET",
+  "socket": {
+    "host": "localhost",
+    "port": 4567,
+    "timeout": 10000,
+    "trustStorePath": "/path/to/truststore",
+    "trustStorePassword": "password"
+  }
+}
+```
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `type` | String | Must be `SOCKET` |
+| `host` | String | The hostname or IP address of the OSGi agent |
+| `port` | Number | The port number of the OSGi agent |
+| `timeout` | Number | Connection timeout in milliseconds |
+| `trustStorePath` | String | (Optional) Path to the SSL truststore |
+| `trustStorePassword` | String | (Optional) Password for the SSL truststore |
+
+### MQTT Connection Example
+
+```json
+{
+  "type": "MQTT",
+  "mqtt": {
+    "server": "broker.hivemq.com",
+    "port": 1883,
+    "timeout": 10000,
+    "clientId": "osgifx-client",
+    "username": "myuser",
+    "password": "mypassword",
+    "pubTopic": "osgifx/pub",
+    "subTopic": "osgifx/sub",
+    "lwtTopic": "osgifx/lwt"
+  }
+}
+```
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `type` | String | Must be `MQTT` |
+| `server` | String | The MQTT broker address |
+| `port` | Number | The MQTT broker port |
+| `timeout` | Number | Connection timeout in milliseconds |
+| `clientId` | String | MQTT Client ID |
+| `username` | String | (Optional) MQTT username |
+| `password` | String | (Optional) MQTT password |
+| `pubTopic` | String | Topic to publish requests to |
+| `subTopic` | String | Topic to subscribe for responses |
+| `lwtTopic` | String | Last Will and Testament topic |

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ For detailed instructions, please refer to the **User Guide** on the website.
 | **ℹ️ DTO Inspector** <br> _Explore standard OSGi Runtime DTOs_ | 2.4.4 | ✅ | 🚀 |
 | **🔍 Advanced Search** <br> _Powerful search across the OSGi framework_ | 2.4.4 | ✅ | 🚀 |
 | **🤖 MCP Support** <br> _Model Context Protocol integration for AI agents. [Read More](MCP_SERVER.md)_ | 2.4.5 | ✅ | 🚧 |
-| **👻 Headless Launch** <br> _Start application without UI via configuration file_ | 2.4.5 | ✅ | 🚧 |
+| **👻 Headless Launch** <br> _Start application with pre-configured connection_ | 2.4.5 | ✅ | 🚧 |
 
 --------------------------------------------------------------------------------------------------------------
 
 ### 💡 Troubleshooting & Tips
 
-*   **👻 Headless Mode:** Starting from 2.4.5, need to connect without the UI? Use the `-Dosgifx.config=/path/to/config.json` system property to launch OSGi.fx with a pre-defined connection.
+*   **👻 Headless Mode:** Starting from 2.4.5, need to connect without the connection wizard? Use the `-Dosgifx.config=/path/to/config.json` system property to launch OSGi.fx with a pre-defined connection. See the [Headless Launch Documentation](HEADLESS_LAUNCH.md).
 *   **🤖 AI Assistance:** OSGi.fx 2.4.5 supports the **Model Context Protocol (MCP)**, allowing AI agents to connect to and debug your OSGi runtime directly! See the [MCP Server Documentation](MCP_SERVER.md).
 
 --------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Added a comprehensive guide explaining how to bypass the connection wizard using a JSON configuration file. Updated the README to provide clearer feature descriptions and linked to the new documentation.

Closes #814