### PR TITLE
Refactored release workflow and automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,13 @@ name: 🚀 Release
 on:
    push:
       tags: ['v*.*.*']
+   workflow_dispatch:
+      inputs:
+         dry_run:
+            description: 'Dry Run'
+            required: true
+            default: false
+            type: boolean
 
 # Only one release at a time
 concurrency:
@@ -24,6 +31,10 @@ jobs:
       runs-on: ubuntu-latest
       
       steps:
+      -  name: 🔍 Check Dry Run Status
+         if: ${{ inputs.dry_run == true }}
+         run: echo "::notice title=Dry Run::DRY RUN MODE ACTIVE - No artifacts will be published"
+
       -  name: 📥 Checkout code
          uses: actions/checkout@v6
          with:
@@ -50,7 +61,6 @@ jobs:
          with:
             node-version: '20'
             registry-url: 'https://registry.npmjs.org'
-            cache: 'npm'
       
       -  name: ⚙️ Configure Git
          run: |
@@ -66,8 +76,30 @@ jobs:
             echo "$GPG_PRIVATE_KEY" | gpg --batch --import
             echo "GPG key imported successfully"
       
-      -  name: 🚀 Build and release
-         run: ./scripts/release.sh
+      -  name: 🐘 Build Bundles
+         run: ./gradlew clean build --info
+
+      -  name: 📦 Export Executable JAR
+         run: ./gradlew :com.osgifx.console.product:export.osgifx --info
+
+      -  name: 🧹 Clean Sonatype Staging
+         run: |
+            rm -rf cnf/cache/sonatype-release/* 2>/dev/null || true
+            rm -rf cnf/target/sonatype-staging/* 2>/dev/null || true
+
+      -  name: 🚀 Release Bundles
+         if: ${{ inputs.dry_run != true }}
+         run: |
+            export GPG_TTY=$(tty)
+            ./gradlew :com.osgifx.console.agent:release --info
+            ./gradlew :com.osgifx.console.agent.api:release --info
+         env:
+            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+            SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+            SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+
+      -  name: 🚀 Publish to Maven Central & GitHub
+         run: ./gradlew :com.osgifx.console.dist:publish jreleaserDeploy -Pjreleaser.enabled=true -Pjreleaser.dryrun=${{ inputs.dry_run }} --info
          env:
             SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
             SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
@@ -76,8 +108,10 @@ jobs:
             JRELEASER_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
             JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.GPG_PUBLIC_KEY }}
             JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
+            JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       -  name: 📢 Publish to npm
+         if: ${{ inputs.dry_run != true }}
          run: npx jdeploy publish
          env:
             NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/com.osgifx.console.dist/build.gradle
+++ b/com.osgifx.console.dist/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 group = 'com.osgifx'
-version = file("${rootProject.projectDir}/cnf/version/app.version").text.trim().replace('.SNAPSHOT', '')
+def appVersion = file("${rootProject.projectDir}/cnf/version/app.version").text.trim().replace('.SNAPSHOT', '')
+version = appVersion
 
 java {
     sourceCompatibility = JavaVersion.VERSION_25
@@ -97,7 +98,10 @@ if (project.hasProperty('jreleaser.enabled')) {
         
         release {
             github {
-                enabled = false
+                enabled = true
+                changelog {
+                    external = "${rootProject.projectDir}/changelogs/v${appVersion}.md"
+                }
             }
         }
         

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 #-------------------------------------------------------------------------------
-bnd_version=7.1.0
+bnd_version=7.2.1
 bnd_snapshots=https://bndtools.jfrog.io/bndtools/libs-release-local


### PR DESCRIPTION
Shifted build and publishing logic from the release script to the GitHub Actions workflow for improved pipeline transparency. Added a dry-run option for manual releases to verify configuration without performing an actual release. Configured JReleaser to automate GitHub releases and pull changelog data from external markdown files. Updated version management to include package.json synchronization for release and development cycles. Automated pushing of version bumps and tags to the remote repository.

Fixes #816