### PR TITLE
Added bundle resource search capabilities

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -72,6 +72,12 @@ Configure your MCP client (e.g., Claude Desktop) to connect via Server-Sent Even
 | **`get_bundle_revisions`** | Retrieves detailed revision info (wiring/capabilities) for a bundle. |
 | **`delete_configuration`** | Deletes an OSGi configuration by PID. |
 | **`execute_agent_extension`** | Executes a named Agent Extension with a context map. |
+| **`search_bundle_resources`** | Searches for resources in a bundle using a glob pattern. |
+| **`list_health_checks`** | Lists the status of all registered Health Checks (Felix HC). |
+| **`get_logger_contexts`** | Lists the Logger Context configuration for bundles, showing effective log levels. |
+| **`list_user_admin_roles`** | Lists all configured user roles and permissions from the UserAdmin service. |
+| **`list_gogo_commands`** | Lists all available Gogo shell commands across all scopes. |
+| **`get_framework_info`** | Retrieves the full OSGi Core Framework DTO, providing a hierarchical view of the system state. |
 
 ## System Prompt / Guiding Principles
 

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
@@ -645,4 +645,13 @@ public interface Agent {
      * @return the raw byte array containing the binary log entries
      */
     byte[] getLogSnapshot(long fromTime, long toTime);
+
+    /**
+     * Searches for resources in the specified bundle using the given pattern.
+     *
+     * @param bundleId the bundle ID
+     * @param pattern the pattern to search for
+     * @return the list of resources
+     */
+    Collection<String> searchBundleResources(long bundleId, String pattern);
 }

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
@@ -35,11 +35,13 @@ import static org.osgi.framework.namespace.HostNamespace.HOST_NAMESPACE;
 import static org.osgi.framework.wiring.BundleRevision.PACKAGE_NAMESPACE;
 
 import java.io.File;
+import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -139,6 +141,27 @@ public final class XBundleAdmin {
             return Collections.emptyList();
         }
         return new ArrayList<>(bundles.values());
+    }
+
+    public List<String> searchBundleResources(final long bundleId, final String pattern) {
+        if (context == null) {
+            logger.atWarn().msg("Bundle context is null").log();
+            return Collections.emptyList();
+        }
+        final Bundle bundle = context.getBundle(bundleId);
+        if (bundle == null) {
+            logger.atWarn().msg("Bundle with ID '{}' not found").arg(bundleId).log();
+            return Collections.emptyList();
+        }
+        final List<String>     resources = new ArrayList<>();
+        final Enumeration<URL> entries   = bundle.findEntries("/", pattern, true);
+
+        if (entries != null) {
+            while (entries.hasMoreElements()) {
+                resources.add(entries.nextElement().getPath());
+            }
+        }
+        return resources;
     }
 
     public static XBundleDTO toDTO(final Bundle bundle, final BundleStartTimeCalculator bundleStartTimeCalculator) {

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -789,6 +789,12 @@ public final class AgentServer implements Agent, Closeable {
     }
 
     @Override
+    public Collection<String> searchBundleResources(final long bundleId, final String pattern) {
+        requireNonNull(pattern, "Pattern cannot be null");
+        return di.getInstance(XBundleAdmin.class).searchBundleResources(bundleId, pattern);
+    }
+
+    @Override
     public XResultDTO createOrUpdateConfiguration(final String pid, final List<ConfigValue> newProperties) {
         requireNonNull(newProperties, "Configuration properties cannot be null");
 

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/SearchBundleResourcesTool.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/SearchBundleResourcesTool.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.osgifx.console.mcp.tool;
+
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.fx.core.log.FluentLogger;
+import org.eclipse.fx.core.log.LoggerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.osgifx.console.mcp.McpTool;
+import com.osgifx.console.mcp.McpToolSchema;
+import com.osgifx.console.propertytypes.McpToolDef;
+import com.osgifx.console.supervisor.Supervisor;
+
+@Component(service = McpTool.class)
+@McpToolDef(name = "search_bundle_resources", description = "Searches for resources in a bundle using a glob pattern")
+public class SearchBundleResourcesTool implements McpTool {
+
+    @Reference(cardinality = OPTIONAL, policyOption = GREEDY)
+    private volatile Supervisor supervisor;
+    @Reference
+    private LoggerFactory       factory;
+    private FluentLogger        logger;
+
+    @Activate
+    void activate() {
+        logger = FluentLogger.of(factory.createLogger(getClass().getName()));
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return McpToolSchema.builder().arg("bundleId", "integer", "The ID of the bundle")
+                .arg("pattern", "string", "The glob pattern to search for (e.g., 'META-INF/*.xml')").build();
+    }
+
+    @Override
+    public Object execute(final Map<String, Object> args) throws Exception {
+        logger.atInfo().log("Executing SearchBundleResourcesTool");
+        final var agent = supervisor.getAgent();
+        if (agent == null) {
+            logger.atWarning().log("Agent is not connected");
+            return Collections.emptyList();
+        }
+
+        final var bundleId = ((Number) args.get("bundleId")).longValue();
+        final var pattern  = (String) args.get("pattern");
+
+        return agent.searchBundleResources(bundleId, pattern);
+    }
+}

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
@@ -148,6 +148,11 @@ public final class SnapshotAgent implements Agent {
     }
 
     @Override
+    public List<String> searchBundleResources(final long bundleId, final String pattern) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public List<XBundleDTO> getAllBundles() {
         return snapshotDTO.bundles;
     }


### PR DESCRIPTION
Implemented a new search mechanism to locate resources within OSGi bundles using glob patterns.

Extended the agent API and its implementation to support remote resource discovery and integrated this functionality into the MCP server as a dedicated tool.

Updated the documentation to reflect the addition of the resource search tool and other framework-related commands available to the MCP server.

Fixes #809