### PR TITLE
Configured milestone closure in JReleaser

### DIFF
--- a/com.osgifx.console.dist/build.gradle
+++ b/com.osgifx.console.dist/build.gradle
@@ -102,6 +102,10 @@ if (project.hasProperty('jreleaser.enabled')) {
                 changelog {
                     external = "${rootProject.projectDir}/changelogs/v${appVersion}.md"
                 }
+                milestone {
+                    name = appVersion
+                    close = true
+                }
             }
         }
         


### PR DESCRIPTION
Added configuration to automatically close the milestone associated with the current version during the release process. This ensured the project management lifecycle was synchronized with the release automation.

Fixes #821