### PR TITLE
Moved data updates to UI thread asynchronously

### DIFF
--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/BundlesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/BundlesInfoSupplier.java
@@ -77,15 +77,18 @@ public final class BundlesInfoSupplier implements RuntimeInfoSupplier, EventHand
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving bundles info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            bundles.setAll(makeNullSafe(agent.getAllBundles()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_BUNDLES_TOPIC);
-            logger.atInfo().log("Bundles info retrieved successfully");
+            logger.atInfo().log("Retrieving bundles info from remote runtime");
+            final var data = makeNullSafe(agent.getAllBundles());
+            threadSync.asyncExec(() -> {
+                bundles.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_BUNDLES_TOPIC);
+                logger.atInfo().log("Bundles info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ComponentsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/ComponentsInfoSupplier.java
@@ -85,15 +85,18 @@ public final class ComponentsInfoSupplier implements RuntimeInfoSupplier, EventH
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving components info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            components.setAll(makeNullSafe(agent.getAllComponents()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_COMPONENTS_TOPIC);
-            logger.atInfo().log("Components info retrieved successfully");
+            logger.atInfo().log("Retrieving components info from remote runtime");
+            final var data = makeNullSafe(agent.getAllComponents());
+            threadSync.asyncExec(() -> {
+                components.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_COMPONENTS_TOPIC);
+                logger.atInfo().log("Components info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HttpComponentsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/HttpComponentsInfoSupplier.java
@@ -85,15 +85,18 @@ public final class HttpComponentsInfoSupplier implements RuntimeInfoSupplier, Ev
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving HTTP components info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            httpComponents.setAll(makeNullSafe(agent.getHttpComponents()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_HTTP_TOPIC);
-            logger.atInfo().log("HTTP components info retrieved successfully");
+            logger.atInfo().log("Retrieving HTTP components info from remote runtime");
+            final var data = makeNullSafe(agent.getHttpComponents());
+            threadSync.asyncExec(() -> {
+                httpComponents.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_HTTP_TOPIC);
+                logger.atInfo().log("HTTP components info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LoggerContextsInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/LoggerContextsInfoSupplier.java
@@ -87,15 +87,18 @@ public final class LoggerContextsInfoSupplier implements RuntimeInfoSupplier, Ev
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving logger contexts info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            loggerContexts.setAll(makeNullSafe(agent.getBundleLoggerContexts()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_LOGGER_CONTEXTS_TOPIC);
-            logger.atInfo().log("Logger contexts info retrieved successfully");
+            logger.atInfo().log("Retrieving logger contexts info from remote runtime");
+            final var data = makeNullSafe(agent.getBundleLoggerContexts());
+            threadSync.asyncExec(() -> {
+                loggerContexts.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_LOGGER_CONTEXTS_TOPIC);
+                logger.atInfo().log("Logger contexts info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PropertiesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/PropertiesInfoSupplier.java
@@ -73,15 +73,18 @@ public final class PropertiesInfoSupplier implements RuntimeInfoSupplier, EventH
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving properties info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            properties.setAll(makeNullSafe(agent.getAllProperties()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_PROPERTIES_TOPIC);
-            logger.atInfo().log("Properties info retrieved successfully");
+            logger.atInfo().log("Retrieving properties info from remote runtime");
+            final var data = makeNullSafe(agent.getAllProperties());
+            threadSync.asyncExec(() -> {
+                properties.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_PROPERTIES_TOPIC);
+                logger.atInfo().log("Properties info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }

--- a/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/RolesInfoSupplier.java
+++ b/com.osgifx.console.data.provider/src/main/java/com/osgifx/console/data/supplier/RolesInfoSupplier.java
@@ -87,15 +87,18 @@ public final class RolesInfoSupplier implements RuntimeInfoSupplier, EventHandle
     public void retrieve() {
         retrieveLock.lock();
         try {
-            logger.atInfo().log("Retrieving roles info from remote runtime");
             final var agent = supervisor.getAgent();
             if (agent == null) {
                 logger.atWarning().log("Agent not connected");
                 return;
             }
-            roles.setAll(makeNullSafe(agent.getAllRoles()));
-            RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_ROLES_TOPIC);
-            logger.atInfo().log("Roles info retrieved successfully");
+            logger.atInfo().log("Retrieving roles info from remote runtime");
+            final var data = makeNullSafe(agent.getAllRoles());
+            threadSync.asyncExec(() -> {
+                roles.setAll(data);
+                RuntimeInfoSupplier.sendEvent(eventAdmin, DATA_RETRIEVED_ROLES_TOPIC);
+                logger.atInfo().log("Roles info retrieved successfully");
+            });
         } finally {
             retrieveLock.unlock();
         }


### PR DESCRIPTION
Updated several info suppliers to wrap observable list modifications and event dispatches within asynchronous execution blocks.

Removed manual reentrant locks in event and log suppliers, delegating synchronization to the thread synchronization service.

Improved thread safety by ensuring that data retrieved from remote agents is applied to UI-bound collections on the appropriate thread.

Fixes #834