### PR TITLE
Refined bundle resource searching capabilities

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -72,7 +72,8 @@ Configure your MCP client (e.g., Claude Desktop) to connect via Server-Sent Even
 | **`get_bundle_revisions`** | Retrieves detailed revision info (wiring/capabilities) for a bundle. |
 | **`delete_configuration`** | Deletes an OSGi configuration by PID. |
 | **`execute_agent_extension`** | Executes a named Agent Extension with a context map. |
-| **`search_bundle_resources`** | Searches for resources in a bundle using a glob pattern. |
+| **`find_bundle_entries`** | Finds files strictly inside the bundle (and its attached fragments). |
+| **`list_bundle_resources`** | Finds resources in the bundle's classpath (includes imports). |
 | **`list_health_checks`** | Lists the status of all registered Health Checks (Felix HC). |
 | **`get_logger_contexts`** | Lists the Logger Context configuration for bundles, showing effective log levels. |
 | **`list_user_admin_roles`** | Lists all configured user roles and permissions from the UserAdmin service. |

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
@@ -647,11 +647,26 @@ public interface Agent {
     byte[] getLogSnapshot(long fromTime, long toTime);
 
     /**
-     * Searches for resources in the specified bundle using the given pattern.
+     * Searches strictly inside the bundle JAR and its attached fragments.
+     * strict wrapper for Bundle.findEntries()
      *
      * @param bundleId the bundle ID
-     * @param pattern the pattern to search for
-     * @return the list of resources
+     * @param path the path to start searching (e.g., "/icons")
+     * @param pattern the file pattern (e.g., "*.png")
+     * @param recursive true to recurse into subdirectories
+     * @return list of resource paths
      */
-    Collection<String> searchBundleResources(long bundleId, String pattern);
+    Collection<String> findBundleEntries(long bundleId, String path, String pattern, boolean recursive);
+
+    /**
+     * Searches the bundle's class space (including imports).
+     * strict wrapper for BundleWiring.listResources()
+     *
+     * @param bundleId the bundle ID
+     * @param path the path to start searching (e.g., "com/example/service")
+     * @param pattern the file pattern (e.g., "*.class")
+     * @param options bitwise options (1=LOCAL, 2=RECURSE)
+     * @return list of resource paths
+     */
+    Collection<String> listBundleResources(long bundleId, String path, String pattern, int options);
 }

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
@@ -143,7 +143,10 @@ public final class XBundleAdmin {
         return new ArrayList<>(bundles.values());
     }
 
-    public List<String> searchBundleResources(final long bundleId, final String pattern) {
+    public List<String> findEntries(final long bundleId,
+                                    final String path,
+                                    final String pattern,
+                                    final boolean recursive) {
         if (context == null) {
             logger.atWarn().msg("Bundle context is null").log();
             return Collections.emptyList();
@@ -154,7 +157,7 @@ public final class XBundleAdmin {
             return Collections.emptyList();
         }
         final List<String>     resources = new ArrayList<>();
-        final Enumeration<URL> entries   = bundle.findEntries("/", pattern, true);
+        final Enumeration<URL> entries   = bundle.findEntries(path, pattern, recursive);
 
         if (entries != null) {
             while (entries.hasMoreElements()) {
@@ -162,6 +165,24 @@ public final class XBundleAdmin {
             }
         }
         return resources;
+    }
+
+    public List<String> listResources(final long bundleId, final String path, final String pattern, final int options) {
+        if (context == null) {
+            logger.atWarn().msg("Bundle context is null").log();
+            return Collections.emptyList();
+        }
+        final Bundle bundle = context.getBundle(bundleId);
+        if (bundle == null) {
+            logger.atWarn().msg("Bundle with ID '{}' not found").arg(bundleId).log();
+            return Collections.emptyList();
+        }
+        final BundleWiring wiring = bundle.adapt(BundleWiring.class);
+        if (wiring == null) {
+            logger.atWarn().msg("Bundle wiring is null for bundle '{}'").arg(bundleId).log();
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(wiring.listResources(path, pattern, options));
     }
 
     public static XBundleDTO toDTO(final Bundle bundle, final BundleStartTimeCalculator bundleStartTimeCalculator) {

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -789,9 +789,23 @@ public final class AgentServer implements Agent, Closeable {
     }
 
     @Override
-    public Collection<String> searchBundleResources(final long bundleId, final String pattern) {
+    public Collection<String> findBundleEntries(final long bundleId,
+                                                final String path,
+                                                final String pattern,
+                                                final boolean recursive) {
+        requireNonNull(path, "Path cannot be null");
         requireNonNull(pattern, "Pattern cannot be null");
-        return di.getInstance(XBundleAdmin.class).searchBundleResources(bundleId, pattern);
+        return di.getInstance(XBundleAdmin.class).findEntries(bundleId, path, pattern, recursive);
+    }
+
+    @Override
+    public Collection<String> listBundleResources(final long bundleId,
+                                                  final String path,
+                                                  final String pattern,
+                                                  final int options) {
+        requireNonNull(path, "Path cannot be null");
+        requireNonNull(pattern, "Pattern cannot be null");
+        return di.getInstance(XBundleAdmin.class).listResources(bundleId, path, pattern, options);
     }
 
     @Override

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/FindBundleEntriesTool.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/FindBundleEntriesTool.java
@@ -33,8 +33,8 @@ import com.osgifx.console.propertytypes.McpToolDef;
 import com.osgifx.console.supervisor.Supervisor;
 
 @Component(service = McpTool.class)
-@McpToolDef(name = "search_bundle_resources", description = "Searches for resources in a bundle using a glob pattern")
-public class SearchBundleResourcesTool implements McpTool {
+@McpToolDef(name = "find_bundle_entries", description = "Finds files strictly inside the bundle (and its attached fragments)")
+public class FindBundleEntriesTool implements McpTool {
 
     @Reference(cardinality = OPTIONAL, policyOption = GREEDY)
     private volatile Supervisor supervisor;
@@ -50,21 +50,25 @@ public class SearchBundleResourcesTool implements McpTool {
     @Override
     public Map<String, Object> inputSchema() {
         return McpToolSchema.builder().arg("bundleId", "integer", "The ID of the bundle")
-                .arg("pattern", "string", "The glob pattern to search for (e.g., 'META-INF/*.xml')").build();
+                .arg("path", "string", "The path to start searching (default: '/')")
+                .arg("pattern", "string", "The glob pattern to search for (default: '*')")
+                .arg("recursive", "boolean", "Recursively search subdirectories (default: true)").build();
     }
 
     @Override
     public Object execute(final Map<String, Object> args) throws Exception {
-        logger.atInfo().log("Executing SearchBundleResourcesTool");
+        logger.atInfo().log("Executing FindBundleEntriesTool");
         final var agent = supervisor.getAgent();
         if (agent == null) {
             logger.atWarning().log("Agent is not connected");
             return Collections.emptyList();
         }
 
-        final var bundleId = ((Number) args.get("bundleId")).longValue();
-        final var pattern  = (String) args.get("pattern");
+        final var bundleId  = ((Number) args.get("bundleId")).longValue();
+        final var path      = (String) args.getOrDefault("path", "/");
+        final var pattern   = (String) args.getOrDefault("pattern", "*");
+        final var recursive = (boolean) args.getOrDefault("recursive", true);
 
-        return agent.searchBundleResources(bundleId, pattern);
+        return agent.findBundleEntries(bundleId, path, pattern, recursive);
     }
 }

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/ListBundleResourcesTool.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/ListBundleResourcesTool.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+package com.osgifx.console.mcp.tool;
+
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.fx.core.log.FluentLogger;
+import org.eclipse.fx.core.log.LoggerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.osgifx.console.mcp.McpTool;
+import com.osgifx.console.mcp.McpToolSchema;
+import com.osgifx.console.propertytypes.McpToolDef;
+import com.osgifx.console.supervisor.Supervisor;
+import org.osgi.framework.wiring.BundleWiring;
+
+@Component(service = McpTool.class)
+@McpToolDef(name = "list_bundle_resources", description = "Finds resources in the bundle's classpath (includes imports)")
+public class ListBundleResourcesTool implements McpTool {
+
+    @Reference(cardinality = OPTIONAL, policyOption = GREEDY)
+    private volatile Supervisor supervisor;
+    @Reference
+    private LoggerFactory       factory;
+    private FluentLogger        logger;
+
+    @Activate
+    void activate() {
+        logger = FluentLogger.of(factory.createLogger(getClass().getName()));
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return McpToolSchema.builder().arg("bundleId", "integer", "The ID of the bundle")
+                .arg("path", "string", "The path to start searching (default: '/')")
+                .arg("pattern", "string", "The glob pattern to search for (default: '*')")
+                .arg("local", "boolean", "Searches only local bundle, no imports (default: false)")
+                .arg("recursive", "boolean", "Recursively search subdirectories (default: true)").build();
+    }
+
+    @Override
+    public Object execute(final Map<String, Object> args) throws Exception {
+        logger.atInfo().log("Executing ListBundleResourcesTool");
+        final var agent = supervisor.getAgent();
+        if (agent == null) {
+            logger.atWarning().log("Agent is not connected");
+            return Collections.emptyList();
+        }
+
+        final var bundleId  = ((Number) args.get("bundleId")).longValue();
+        final var path      = (String) args.getOrDefault("path", "/");
+        final var pattern   = (String) args.getOrDefault("pattern", "*");
+        final var local     = (boolean) args.getOrDefault("local", false);
+        final var recursive = (boolean) args.getOrDefault("recursive", true);
+
+        var options = 0;
+        if (recursive) {
+            options |= BundleWiring.LISTRESOURCES_RECURSE;
+        }
+        if (local) {
+            options |= BundleWiring.LISTRESOURCES_LOCAL;
+        }
+
+        return agent.listBundleResources(bundleId, path, pattern, options);
+    }
+}

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
@@ -148,7 +148,18 @@ public final class SnapshotAgent implements Agent {
     }
 
     @Override
-    public List<String> searchBundleResources(final long bundleId, final String pattern) {
+    public List<String> findBundleEntries(final long bundleId,
+                                          final String path,
+                                          final String pattern,
+                                          final boolean recursive) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> listBundleResources(final long bundleId,
+                                            final String path,
+                                            final String pattern,
+                                            final int options) {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
Separated the generic bundle resource search into two specialized operations to provide greater precision and control over resource lookups. Introduced findBundleEntries for searching strictly within the bundle JAR and its fragments, and listBundleResources for searching the wider class space including imported packages. Updated the MCP server tools and documentation to support these distinct search methods, ensuring users can differentiate between JAR entries and classpath resources.

Fixes #839