### PR TITLE
Guarded services with package wirings

### DIFF
--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -1059,7 +1059,12 @@ public final class AgentServer implements Agent, Closeable {
 
     @Override
     public RuntimeDTO getRuntimeDTO() {
-        return di.getInstance(XDtoAdmin.class).runtime();
+        final boolean isScrWired = di.getInstance(PackageWirings.class).isScrWired();
+        if (isScrWired) {
+            return di.getInstance(XDtoAdmin.class).runtime();
+        }
+        logger.atWarn().msg(packageNotWired(SCR)).log();
+        return null;
     }
 
     @Override


### PR DESCRIPTION
Guarded the instantiation and registration of various admin services based on the availability of their underlying OSGi packages. Modified the dependency injection module to check for package wirings before binding instances and providers, preventing errors when optional dependencies are absent. Updated the agent server to verify SCR availability before retrieving the runtime DTO.

Fixes #843