### PR TITLE
Added info button and updated color descriptions

### DIFF
--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxUI.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxUI.java
@@ -156,11 +156,19 @@ public final class BundlesFxUI {
         statusBar.clearAllInRight();
         statusBar.addTo(parent);
         if (isConnected) {
+            final var infoNode = Fx.initStatusBarButton(this::showInfo, "Info", "INFO");
+            statusBar.addToRight(infoNode);
+            statusBar.addToRight(new Separator(VERTICAL));
             final var node = Fx.initStatusBarButton(this::refreshData, "Refresh", "REFRESH");
             if (!isSnapshotAgent) {
                 statusBar.addToRight(node);
             }
         }
+    }
+
+    private void showInfo() {
+        FxDialog.showInfoDialog("Bundle Color Information", "Slate Blue colored entries are fragments.",
+                getClass().getClassLoader());
     }
 
     private void initSearchFilterResetButton(final String description) {

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxUI.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxUI.java
@@ -167,7 +167,7 @@ public final class ServicesFxUI {
     }
 
     private void showInfo() {
-        FxDialog.showInfoDialog("Service Color Information", "Violet colored entries are OSGi SCR components.",
+        FxDialog.showInfoDialog("Service Color Information", "Slate Blue colored entries are OSGi SCR components.",
                 getClass().getClassLoader());
     }
 


### PR DESCRIPTION
Added an information button to the bundles status bar to explain the meaning of color-coded fragment entries. Updated the services UI color description to correctly identify SCR components as slate blue for visual consistency.

Fixed #844