### PR TITLE
Improved graph generation and fixed logic errors

### DIFF
--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxBundleController.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxBundleController.java
@@ -213,6 +213,7 @@ public final class GraphFxBundleController implements GraphController {
     @FXML
     private void generateGraph(final ActionEvent event) {
         logger.atInfo().log("Generating graph for bundles");
+        final var selection       = wiringSelection.getSelectionModel().getSelectedIndex();
         final var selectedBundles = Lists.newArrayList(bundlesList.getCheckModel().getCheckedItems());
         if (selectedBundles.isEmpty()) {
             logger.atInfo().log("No bundle has been selected. Skipped graph generation.");
@@ -223,8 +224,6 @@ public final class GraphFxBundleController implements GraphController {
 
             @Override
             protected Void call() throws Exception {
-                progressPane.setVisible(true);
-                final var selection = wiringSelection.getSelectionModel().getSelectedIndex();
 
                 final Collection<GraphPath<BundleVertex, DefaultEdge>> dependencies;
                 if (selection == 0) {
@@ -259,7 +258,14 @@ public final class GraphFxBundleController implements GraphController {
                 final var layoutIndex = layoutSelection.getSelectionModel().getSelectedIndex();
                 graphView.setLayout(getLayoutName(layoutIndex));
             }
+
+            @Override
+            protected void failed() {
+                logger.atError().withException(getException()).log("Graph generation failed");
+                progressPane.setVisible(false);
+            }
         };
+        progressPane.setVisible(true);
         graphPane.setCenter(progressPane);
         if (graphGenFuture != null) {
             graphGenFuture.cancel(true);

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxComponentController.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/GraphFxComponentController.java
@@ -232,7 +232,6 @@ public final class GraphFxComponentController implements GraphController {
 
             @Override
             protected Void call() throws Exception {
-                progressPane.setVisible(true);
 
                 if (selection == 0) {
                     logger.atDebug().log("Generating all graph paths for service components that are required by '%s'",
@@ -266,7 +265,14 @@ public final class GraphFxComponentController implements GraphController {
                 final var layoutIndex = layoutSelection.getSelectionModel().getSelectedIndex();
                 graphView.setLayout(getLayoutName(layoutIndex));
             }
+
+            @Override
+            protected void failed() {
+                logger.atError().withException(getException()).log("Graph generation failed");
+                progressPane.setVisible(false);
+            }
         };
+        progressPane.setVisible(true);
         graphPane.setCenter(progressPane);
         if (graphGenFuture != null) {
             graphGenFuture.cancel(true);

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeBundleGraph.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/RuntimeBundleGraph.java
@@ -133,11 +133,13 @@ public final class RuntimeBundleGraph {
             final var target              = new BundleVertex(b.symbolicName, b.id);
             final var isTargetVertexAdded = graph.addVertex(target);
             if (isTargetVertexAdded) {
-                processedBundles.add(source.toString());
+                processedBundles.add(target.toString());
             }
             graph.addEdge(source, target);
             final var dto = bundleMap.get(target.toString());
-            prepareGraph(dto, graph, strategy, processedBundles);
+            if (dto != null) {
+                prepareGraph(dto, graph, strategy, processedBundles);
+            }
         }
     }
 

--- a/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/WebGraphView.java
+++ b/com.osgifx.console.ui.graph/src/main/java/com/osgifx/console/ui/graph/WebGraphView.java
@@ -40,6 +40,7 @@ public final class WebGraphView extends BorderPane {
 
     public WebGraphView() {
         webView   = new WebView();
+        webView.setContextMenuEnabled(false);
         webEngine = webView.getEngine();
         setCenter(webView);
 


### PR DESCRIPTION
Ensured the progress indicator displayed correctly before the graph generation task started. Added error handling to hide the progress pane and logged exceptions when graph generation failed. Fixed a bug in bundle tracking and added null checks to prevent potential crashes during graph construction. Disabled the context menu in the web-based graph view for a cleaner user experience.

Fixes #852