### PR TITLE
Improved agent shutdown and property cleanup

### DIFF
--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -201,6 +201,10 @@ public final class AgentServer implements Agent, Closeable {
         }
     }
 
+    public RpcType getRpcType() {
+        return rpcType;
+    }
+
     public BundleContext getContext() {
         return di.getInstance(BundleContext.class);
     }

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/AgentCommand.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/starter/AgentCommand.java
@@ -82,9 +82,9 @@ public final class AgentCommand {
      * Stops the socket agent and clears the related system properties.
      */
     public void stopSocket() {
-        System.setProperty(AGENT_SOCKET_PORT_KEY, "");
-        System.setProperty(AGENT_SOCKET_SECURE_COMMUNICATION_KEY, "");
-        System.setProperty(AGENT_SOCKET_SECURE_COMMUNICATION_SSL_CONTEXT_FILTER_KEY, "");
+        System.clearProperty(AGENT_SOCKET_PORT_KEY);
+        System.clearProperty(AGENT_SOCKET_SECURE_COMMUNICATION_KEY);
+        System.clearProperty(AGENT_SOCKET_SECURE_COMMUNICATION_SSL_CONTEXT_FILTER_KEY);
 
         try {
             activator.stopSocketAgent();
@@ -132,9 +132,9 @@ public final class AgentCommand {
      * Stops the MQTT agent and clears the related system properties.
      */
     public void stopMqtt() {
-        System.setProperty(AGENT_MQTT_PROVIDER_KEY, "");
-        System.setProperty(AGENT_MQTT_PUB_TOPIC_KEY, "");
-        System.setProperty(AGENT_MQTT_SUB_TOPIC_KEY, "");
+        System.clearProperty(AGENT_MQTT_PROVIDER_KEY);
+        System.clearProperty(AGENT_MQTT_PUB_TOPIC_KEY);
+        System.clearProperty(AGENT_MQTT_SUB_TOPIC_KEY);
 
         try {
             activator.stopMqttAgent();


### PR DESCRIPTION
Ensured all active socket and MQTT agents were explicitly closed and removed upon stopping to prevent hanging connections. Updated system property management to use clearProperty instead of empty strings for better configuration cleanup.

Fixes #855