### PR TITLE
Prevented NullPointerException in role retrieval

### DIFF
--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XUserAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XUserAdmin.java
@@ -67,8 +67,11 @@ public final class XUserAdmin {
         }
         final List<XRoleDTO> dtos = new ArrayList<>();
         try {
-            for (final Role role : userAdmin.getRoles(null)) {
-                dtos.add(toRole(role, new HashSet<>()));
+            final Role[] roles = userAdmin.getRoles(null);
+            if (roles != null) {
+                for (final Role role : roles) {
+                    dtos.add(toRole(role, new HashSet<>()));
+                }
             }
         } catch (final Exception e) {
             // for any exception occurs in remote runtime


### PR DESCRIPTION
Handled scenarios where the user admin service returns null for roles. This ensures the agent does not crash when processing an empty or missing role list.

Fixed #861