### PR TITLE
Applied default sorting to various UI tables

### DIFF
--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/MqttConnectionSettingsDialogController.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/MqttConnectionSettingsDialogController.java
@@ -69,6 +69,8 @@ public final class MqttConnectionSettingsDialogController {
                 .addListener((_, _, newSettings) -> selectedSettings.publish(newSettings));
 
         TableFilter.forTableView(connectionTable).apply();
+        connectionTable.getSortOrder().add(nameColumn);
+        connectionTable.sort();
         logger.atDebug().log("FXML controller has been initialized");
     }
 

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/SocketConnectionSettingsDialogController.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/fxml/controller/SocketConnectionSettingsDialogController.java
@@ -65,6 +65,8 @@ public final class SocketConnectionSettingsDialogController {
                 .addListener((_, _, newSettings) -> selectedSettings.publish(newSettings));
 
         TableFilter.forTableView(connectionTable).apply();
+        connectionTable.getSortOrder().add(nameColumn);
+        connectionTable.sort();
         logger.atDebug().log("FXML controller has been initialized");
     }
 

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundleDetailsFxController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundleDetailsFxController.java
@@ -319,14 +319,40 @@ public final class BundleDetailsFxController {
 
     private void applyTableFilters() {
         TableFilter.forTableView(exportedPackagesNameTable).apply();
+        exportedPackagesNameTable.getSortOrder().add(exportedPackagesNameTableColumn);
+        exportedPackagesNameTable.sort();
+
         TableFilter.forTableView(registeredServicesTable).apply();
+        registeredServicesTable.getSortOrder().add(registeredServicesIdTableColumn);
+        registeredServicesTable.sort();
+
         TableFilter.forTableView(manifestHeadersTable).apply();
+        manifestHeadersTable.getSortOrder().add(manifestHeadersTableColumn1);
+        manifestHeadersTable.sort();
+
         TableFilter.forTableView(importedPackagesTable).apply();
+        importedPackagesTable.getSortOrder().add(importedPackagesNameTableColumn);
+        importedPackagesTable.sort();
+
         TableFilter.forTableView(wiredBundlesAsProviderTable).apply();
+        wiredBundlesAsProviderTable.getSortOrder().add(wiredBundlesAsProviderBsnTableColumn);
+        wiredBundlesAsProviderTable.sort();
+
         TableFilter.forTableView(wiredBundlesAsRequirerTable).apply();
+        wiredBundlesAsRequirerTable.getSortOrder().add(wiredBundlesAsRequirerBsnTableColumn);
+        wiredBundlesAsRequirerTable.sort();
+
         TableFilter.forTableView(usedServicesTable).apply();
+        usedServicesTable.getSortOrder().add(usedServicesIdTableColumn);
+        usedServicesTable.sort();
+
         TableFilter.forTableView(hostBundlesTable).apply();
+        hostBundlesTable.getSortOrder().add(hostBundlesBsnTableColumn);
+        hostBundlesTable.sort();
+
         TableFilter.forTableView(attachedFragmentsTable).apply();
+        attachedFragmentsTable.getSortOrder().add(attachedFragmentsBsnTableColumn);
+        attachedFragmentsTable.sort();
     }
 
     private Map<String, Object> createCommandMap(final long value) {

--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
@@ -130,6 +130,8 @@ public final class BundlesFxController {
         table.setItems(filteredList);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(symbolicNameColumn);
+        table.sort();
     }
 
     @Inject

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
@@ -238,6 +238,8 @@ public final class ComponentDetailsFxController {
         }
 
         referencesTable.setItems(FXCollections.observableArrayList(component.references));
+        referencesTable.getSortOrder().add(nameColumn);
+        referencesTable.sort();
 
         areReferenceTableNodesLoader.set(true);
     }
@@ -268,9 +270,18 @@ public final class ComponentDetailsFxController {
 
     private void applyTableFilters() {
         TableFilter.forTableView(referencesTable).apply();
+
         TableFilter.forTableView(propertiesTable).apply();
+        propertiesTable.getSortOrder().add(propertiesTableColumn1);
+        propertiesTable.sort();
+
         TableFilter.forTableView(boundServicesTable).apply();
+        boundServicesTable.getSortOrder().add(boundServicesNameColumn);
+        boundServicesTable.sort();
+
         TableFilter.forTableView(unboundServicesTable).apply();
+        unboundServicesTable.getSortOrder().add(unboundServicesNameColumn);
+        unboundServicesTable.sort();
     }
 
 }

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
@@ -132,6 +132,8 @@ public final class ComponentsFxController {
         table.setItems(filteredList);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(componentNameColumn);
+        table.sort();
     }
 
     @Inject

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
@@ -130,6 +130,8 @@ public final class ConfigurationsFxController {
         table.setItems(filteredList);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(pidColumn);
+        table.sort();
     }
 
     @Inject

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventDetailsFxController.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventDetailsFxController.java
@@ -65,6 +65,8 @@ public final class EventDetailsFxController {
         propertiesKeyTableColumn.setCellValueFactory(p -> new SimpleStringProperty(p.getValue().getKey()));
         propertiesValueTableColumn.setCellValueFactory(p -> new SimpleStringProperty(p.getValue().getValue()));
         propertiesTable.setItems(FXCollections.observableArrayList(event.properties.entrySet()));
+        propertiesTable.getSortOrder().add(propertiesKeyTableColumn);
+        propertiesTable.sort();
 
         Fx.addContextMenuToCopyContent(propertiesTable);
     }

--- a/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialogController.java
+++ b/com.osgifx.console.ui.extension/src/main/java/com/osgifx/console/ui/extension/dialog/ExtensionsViewDialogController.java
@@ -69,6 +69,9 @@ public final class ExtensionsViewDialogController {
         displayNameColumn.setCellValueFactory(new DTOCellValueFactory<>("displayName", String.class));
         versionColumn.setCellValueFactory(new DTOCellValueFactory<>("version", String.class));
 
+        extensionsList.getSortOrder().add(nameColumn);
+        extensionsList.sort();
+
         initContextMenu();
     }
 

--- a/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
+++ b/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
@@ -126,6 +126,8 @@ public final class HttpFxController {
 
         table.setItems(dataProvider.httpComponents());
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(componentColumn);
+        table.sort();
     }
 
 }

--- a/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
+++ b/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
@@ -75,6 +75,8 @@ public final class LeaksFxController {
 
         table.setItems(dataProvider.leaks());
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(bsnColumn);
+        table.sort();
     }
 
 }

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
@@ -108,6 +108,8 @@ public final class LogConfigurationsFxController {
         table.setItems(loggerContexts);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(nameColumn);
+        table.sort();
     }
 
 }

--- a/com.osgifx.console.ui.mcp/src/main/java/com/osgifx/console/ui/mcp/McpFxController.java
+++ b/com.osgifx.console.ui.mcp/src/main/java/com/osgifx/console/ui/mcp/McpFxController.java
@@ -149,6 +149,8 @@ public final class McpFxController {
         toolsTable.setItems(tools);
         Fx.addContextMenuToCopyContent(toolsTable);
         TableFilter.forTableView(toolsTable).lazy(true).apply();
+        toolsTable.getSortOrder().add(nameColumn);
+        toolsTable.sort();
     }
 
     private void initLogsTable() {
@@ -159,6 +161,9 @@ public final class McpFxController {
         logsTable.setItems(logs);
         Fx.addContextMenuToCopyContent(logsTable);
         TableFilter.forTableView(logsTable).lazy(true).apply();
+        timestampColumn.setSortType(TableColumn.SortType.DESCENDING);
+        logsTable.getSortOrder().add(timestampColumn);
+        logsTable.sort();
     }
 
     private void updateTools() {

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackageDetailsFxController.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackageDetailsFxController.java
@@ -76,7 +76,12 @@ public final class PackageDetailsFxController {
         importersTable.setItems(FXCollections.observableArrayList(pkg.importers));
 
         TableFilter.forTableView(exportersTable).apply();
+        exportersTable.getSortOrder().add(exportersTableBsnColumn);
+        exportersTable.sort();
+
         TableFilter.forTableView(importersTable).apply();
+        importersTable.getSortOrder().add(importersTableBsnColumn);
+        importersTable.sort();
 
         Fx.addContextMenuToCopyContent(exportersTable);
         Fx.addContextMenuToCopyContent(importersTable);

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
@@ -122,6 +122,8 @@ public final class PackagesFxController {
         table.setItems(filteredList);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(nameColumn);
+        table.sort();
     }
 
     @Inject

--- a/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxController.java
+++ b/com.osgifx.console.ui.properties/src/main/java/com/osgifx/console/ui/properties/PropertiesFxController.java
@@ -72,6 +72,8 @@ public final class PropertiesFxController {
 
         propertyTable.setItems(dataProvider.properties());
         TableFilter.forTableView(propertyTable).lazy(true).apply();
+        propertyTable.getSortOrder().add(propertyName);
+        propertyTable.sort();
     }
 
 }

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
@@ -103,6 +103,8 @@ public final class RolesFxController {
 
         table.setItems(dataProvider.roles());
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(roleNameColumn);
+        table.sort();
     }
 
 }

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServiceDetailsFxController.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServiceDetailsFxController.java
@@ -72,6 +72,8 @@ public final class ServiceDetailsFxController {
         objectClassesList.getItems().addAll(service.types);
 
         TableFilter.forTableView(propertiesTable).apply();
+        propertiesTable.getSortOrder().add(propertiesTableColumn1);
+        propertiesTable.sort();
 
         Fx.addContextMenuToCopyContent(propertiesTable);
         Fx.addContextMenuToCopyContent(objectClassesList);

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
@@ -125,6 +125,8 @@ public final class ServicesFxController {
         table.setItems(filteredList);
 
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(objectClassColumn);
+        table.sort();
     }
 
     @Inject

--- a/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
+++ b/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
@@ -92,6 +92,8 @@ public final class ThreadsFxController {
 
         table.setItems(dataProvider.threads());
         TableFilter.forTableView(table).lazy(true).apply();
+        table.getSortOrder().add(nameColumn);
+        table.sort();
     }
 
 }


### PR DESCRIPTION
Added default sort orders to table views in multiple UI controllers to ensure data is presented in a consistently organized manner. This update ensured that tables for bundles, components, configurations, services, and other views are automatically sorted by their primary columns upon initialization or data loading.

Fixes #499