### PR TITLE
Warned about missing command allowlist settings

### DIFF
--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -477,6 +477,9 @@ public final class AgentServer implements Agent, Closeable {
         final String allowlistRaw = context.getProperty(allowlistKey);
         final String allowlist    = allowlistRaw != null ? allowlistRaw : "*";
         if ("*".equals(allowlist)) {
+            logger.atWarn().msg(
+                    "Notice: In the absence of a defined allowlist, all commands are currently permitted. It is highly encouraged to set '{}'.")
+                    .arg(allowlistKey).log();
             return null;
         }
         final String[] allowedCommands = allowlist.split(",");


### PR DESCRIPTION
Logged a warning message when the agent was configured without a restricted command allowlist. Encouraged the definition of an allowlist to improve security and prevent the execution of unauthorized commands.

Fixes #849