### PR TITLE
Added JavaFX runtime validation

### DIFF
--- a/scripts/RunOSGiFx
+++ b/scripts/RunOSGiFx
@@ -18,6 +18,7 @@
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.module.ModuleFinder;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -54,6 +55,7 @@ public class RunOSGiFx {
     public static void main(String[] args) {
         try {
             validateJavaVersion();
+            validateJavaFXSupport();
 
             String       jarPath     = null;
             String       gav         = null;
@@ -124,6 +126,13 @@ public class RunOSGiFx {
         int version = Runtime.version().feature();
         if (version < 25) {
             failFast("Java 25 or higher is required. Current version: " + version);
+        }
+    }
+
+    private static void validateJavaFXSupport() {
+        boolean hasJavaFx = ModuleFinder.ofSystem().find("javafx.base").isPresent();
+        if (!hasJavaFx) {
+            failFast("JavaFX support is missing in the current Java runtime. Please use a JDK that bundles JavaFX (e.g., Azul Zulu FX, BellSoft Liberica Full).");
         }
     }
 


### PR DESCRIPTION
Verified the presence of JavaFX modules during startup to provide early failure feedback. Included clear error messaging and suggested specific JDK distributions to help users resolve environment issues.

Closes #876