### PR TITLE
Refined UI fragment headers and tab ordering

### DIFF
--- a/com.osgifx.console.extension.ui.tictactoe/bnd.bnd
+++ b/com.osgifx.console.extension.ui.tictactoe/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -fixupmessages      : 'No translation found'
 -privatepackage     : com.osgifx.console.extension.tictactoe
 -includeresource    : \

--- a/com.osgifx.console.ui.batchinstall/bnd.bnd
+++ b/com.osgifx.console.ui.batchinstall/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.bundles/bnd.bnd
+++ b/com.osgifx.console.ui.bundles/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.cdi/bnd.bnd
+++ b/com.osgifx.console.ui.cdi/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.cdi/fragment.e4xmi
+++ b/com.osgifx.console.ui.cdi/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_j7J3oCBGEey33dbookdebQ">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_j7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:16">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_j7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:17">
     <elements xsi:type="basic:Part" xmi:id="_j7J3oiBGEey33dbookdebQ" elementId="com.osgifx.console.application.tab.cdi" contributionURI="bundleclass://com.osgifx.console.ui.cdi/com.osgifx.console.ui.cdi.CdiFxUI" label="CDI" iconURI="platform:/plugin/com.osgifx.console.ui.cdi/graphic/icons/cdi.png" tooltip="Shows CDI runtime information" closeable="true"/>
   </fragments>
 </fragment:ModelFragments>

--- a/com.osgifx.console.ui.components/bnd.bnd
+++ b/com.osgifx.console.ui.components/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.configurations/bnd.bnd
+++ b/com.osgifx.console.ui.configurations/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.dmt/bnd.bnd
+++ b/com.osgifx.console.ui.dmt/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.dmt/fragment.e4xmi
+++ b/com.osgifx.console.ui.dmt/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_s7J3oCBGEey33dbookdebQ">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:18">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:20">
     <elements xsi:type="basic:Part" xmi:id="_s7J3oiBGEey33dbookdebQ" elementId="com.osgifx.console.application.tab.dmt" contributionURI="bundleclass://com.osgifx.console.ui.dmt/com.osgifx.console.ui.dmt.DmtFxUI" label="DMT" iconURI="platform:/plugin/com.osgifx.console.ui.dmt/graphic/icons/tree.png" tooltip="Shows all available DMT nodes in the remote framework" closeable="true"/>
   </fragments>
 </fragment:ModelFragments>

--- a/com.osgifx.console.ui.dto/bnd.bnd
+++ b/com.osgifx.console.ui.dto/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.dto/fragment.e4xmi
+++ b/com.osgifx.console.ui.dto/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_s7J3oCBGEey33dbookdebQ">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:17">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:19">
     <elements xsi:type="basic:Part" xmi:id="_s7J3oiBGEey33dbookdebQ" elementId="com.osgifx.console.application.tab.dto" contributionURI="bundleclass://com.osgifx.console.ui.dto/com.osgifx.console.ui.dto.DtoFxUI" label="DTO" iconURI="platform:/plugin/com.osgifx.console.ui.dto/graphic/icons/dto.png" tooltip="Shows all available runtime DTOs in the remote framework" closeable="true"/>
   </fragments>
 </fragment:ModelFragments>

--- a/com.osgifx.console.ui.events/bnd.bnd
+++ b/com.osgifx.console.ui.events/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.extension/bnd.bnd
+++ b/com.osgifx.console.ui.extension/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.gogo/bnd.bnd
+++ b/com.osgifx.console.ui.gogo/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.graph/bnd.bnd
+++ b/com.osgifx.console.ui.graph/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 				      fragment.e4xmi = fragment.e4xmi,\
 				      css = css,\

--- a/com.osgifx.console.ui.healthchecks/bnd.bnd
+++ b/com.osgifx.console.ui.healthchecks/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.healthchecks/fragment.e4xmi
+++ b/com.osgifx.console.ui.healthchecks/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_s7J3oCBGEey33dbookdebQ">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:19">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:22">
     <elements xsi:type="basic:Part" xmi:id="_s7J3oiBGEey33dbookdebQ" elementId="com.osgifx.console.application.tab.healthchecks" contributionURI="bundleclass://com.osgifx.console.ui.healthchecks/com.osgifx.console.ui.healthchecks.HealthCheckFxUI" label="Healthchecks" iconURI="platform:/plugin/com.osgifx.console.ui.healthchecks/graphic/icons/healthcheck.png" tooltip="Executes Felix Healthchecks" closeable="true"/>
   </fragments>
 </fragment:ModelFragments>

--- a/com.osgifx.console.ui.heap/bnd.bnd
+++ b/com.osgifx.console.ui.heap/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.http/bnd.bnd
+++ b/com.osgifx.console.ui.http/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.jaxrs/bnd.bnd
+++ b/com.osgifx.console.ui.jaxrs/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.leaks/bnd.bnd
+++ b/com.osgifx.console.ui.leaks/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.logs/bnd.bnd
+++ b/com.osgifx.console.ui.logs/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.mcp/bnd.bnd
+++ b/com.osgifx.console.ui.mcp/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.mcp/fragment.e4xmi
+++ b/com.osgifx.console.ui.mcp/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmi:id="_mcp_ui_fragment">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_mcp_ui_part_fragment" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:1">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_mcp_ui_part_fragment" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:21">
     <elements xsi:type="basic:Part" xmi:id="com.osgifx.console.ui.mcp.part" elementId="com.osgifx.console.ui.mcp.part" contributionURI="bundleclass://com.osgifx.console.ui.mcp/com.osgifx.console.ui.mcp.McpFxUI" label="MCP" iconURI="platform:/plugin/com.osgifx.console.ui.mcp/graphic/icons/mcp.png" tooltip="Model Context Protocol Server Control" closeable="true"/>
   </fragments>
 </fragment:ModelFragments>

--- a/com.osgifx.console.ui.overview/bnd.bnd
+++ b/com.osgifx.console.ui.overview/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.packages/bnd.bnd
+++ b/com.osgifx.console.ui.packages/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.properties/bnd.bnd
+++ b/com.osgifx.console.ui.properties/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.roles/bnd.bnd
+++ b/com.osgifx.console.ui.roles/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.roles/fragment.e4xmi
+++ b/com.osgifx.console.ui.roles/fragment.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ASCII"?>
 <fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_s7J3oCBGEey33dbookdebQ">
-  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:16">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_s7J3oSBGEey33dbookdebQ" featurename="children" parentElementId="com.osgifx.console.ui.extensions.partstack" positionInList="index:18">
     <elements xsi:type="basic:Part" xmi:id="_s7J3oiBGEey33dbookdebQ" elementId="com.osgifx.console.application.tab.roles" contributionURI="bundleclass://com.osgifx.console.ui.roles/com.osgifx.console.ui.roles.RolesFxUI" label="Roles" iconURI="platform:/plugin/com.osgifx.console.ui.roles/graphic/icons/roles.png" tooltip="Shows all available User Admin roles in the remote framework" closeable="true"/>
   </fragments>
   <fragments xsi:type="fragment:StringModelFragment" xmi:id="_gdcQYH-WEeyYfeV-7UqQeg" featurename="children" parentElementId="com.osgifx.console.application.menu.actions">

--- a/com.osgifx.console.ui.search/bnd.bnd
+++ b/com.osgifx.console.ui.search/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.services/bnd.bnd
+++ b/com.osgifx.console.ui.services/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.snapshot/bnd.bnd
+++ b/com.osgifx.console.ui.snapshot/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -privatepackage     : com.osgifx.console.ui.snapshot*
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\

--- a/com.osgifx.console.ui.terminal/bnd.bnd
+++ b/com.osgifx.console.ui.terminal/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\

--- a/com.osgifx.console.ui.threads/bnd.bnd
+++ b/com.osgifx.console.ui.threads/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-SymbolicName : ${p}; singleton:=true
-Model-Fragment: fragment.e4xmi;apply=always
+Model-Fragment      : fragment.e4xmi
 -includeresource    : \
 					  fragment.e4xmi = fragment.e4xmi,\
 					  css = css,\


### PR DESCRIPTION
Removed redundant apply attributes from Model-Fragment headers across various modules to clean up bundle configurations. Adjusted position indices within UI model fragments to improve the display sequence of application tabs.

Fixes #878