### PR TITLE
Corrected component type in JaxRs controller

### DIFF
--- a/com.osgifx.console.ui.jaxrs/src/main/java/com/osgifx/console/ui/jaxrs/JaxRsFxController.java
+++ b/com.osgifx.console.ui.jaxrs/src/main/java/com/osgifx/console/ui/jaxrs/JaxRsFxController.java
@@ -36,7 +36,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.layout.BorderPane;
+import javafx.scene.control.TabPane;
 
 public final class JaxRsFxController {
 
@@ -74,7 +74,7 @@ public final class JaxRsFxController {
     }
 
     private void createControls() {
-        final var expandedNode   = (BorderPane) Fx.loadFXML(loader, context, "/fxml/expander-column-content.fxml");
+        final var expandedNode   = (TabPane) Fx.loadFXML(loader, context, "/fxml/expander-column-content.fxml");
         final var controller     = (JaxRsDetailsFxController) loader.getController();
         final var expanderColumn = new TableRowExpanderColumn<XJaxRsComponentDTO>(current -> {
                                      if (previouslyExpanded != null


### PR DESCRIPTION
Updated the cast of the expanded node from BorderPane to TabPane to resolve a type mismatch with the associated FXML.

Fixes #881