### PR TITLE
Added support for retrieving bundle data files

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -83,6 +83,7 @@ Configure your MCP client (e.g., Claude Desktop) to connect via Server-Sent Even
 | **`execute_agent_extension`** | Executes a named Agent Extension with a context map. |
 | **`find_bundle_entries`** | Finds files strictly inside the bundle (and its attached fragments). |
 | **`list_bundle_resources`** | Finds resources in the bundle's classpath (includes imports). |
+| **`get_bundle_data_file`** | Retrieves the content of a file from a bundle's persistent storage area. |
 | **`list_health_checks`** | Lists the status of all registered Health Checks (Felix HC). |
 | **`get_logger_contexts`** | Lists the Logger Context configuration for bundles, showing effective log levels. |
 | **`list_user_admin_roles`** | Lists all configured user roles and permissions from the UserAdmin service. |

--- a/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
+++ b/com.osgifx.console.agent.api/src/main/java/com/osgifx/console/agent/Agent.java
@@ -240,6 +240,26 @@ public interface Agent {
     List<BundleRevisionDTO> getBundleRevisons(final long... bundleId) throws Exception;
 
     /**
+     * Retrieves the content of a file from the specified bundle's persistent
+     * storage area ({@code BundleContext.getDataFile()}).
+     * <p>
+     * The {@code fileName} is resolved relative to the bundle's private data
+     * directory. Path traversal sequences (e.g., {@code ".."}) are not permitted
+     * and will result in an {@link IllegalArgumentException}.
+     *
+     * @param id the bundle ID
+     * @param fileName the name of the file to retrieve, relative to the bundle's
+     *            data area (cannot be {@code null})
+     * @return the content of the file as a string, or {@code null} if the bundle
+     *         does not exist, does not have an active {@code BundleContext}, or
+     *         the specified file does not exist
+     * @throws IllegalArgumentException if {@code fileName} contains path traversal
+     *             sequences
+     * @throws Exception if an error occurs while reading the file
+     */
+    String getBundleDataFile(long id, String fileName) throws Exception;
+
+    /**
      * Redirect I/O from port. Port can be {@link #CONSOLE},
      * {@link #COMMAND_SESSION}, {@link #NONE}, or a TCP Telnet port.
      *

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/admin/XBundleAdmin.java
@@ -74,6 +74,7 @@ import com.osgifx.console.agent.dto.XServiceInfoDTO;
 import com.osgifx.console.agent.provider.BundleStartTimeCalculator;
 import com.osgifx.console.agent.provider.BundleStartTimeCalculator.BundleStartDuration;
 
+import aQute.lib.io.IO;
 import jakarta.inject.Inject;
 
 public final class XBundleAdmin {
@@ -253,6 +254,31 @@ public final class XBundleAdmin {
             return Collections.emptyList();
         }
         return new ArrayList<>(wiring.listResources(path, pattern, options));
+    }
+
+    public String getDataFile(final long bundleId, final String fileName) throws Exception {
+        if (context == null) {
+            logger.atWarn().msg("Bundle context is null").log();
+            return null;
+        }
+        if (fileName.contains("..")) {
+            throw new IllegalArgumentException("Path traversal is not allowed in fileName");
+        }
+        final Bundle bundle = context.getBundle(bundleId);
+        if (bundle == null) {
+            logger.atWarn().msg("Bundle with ID '{}' not found").arg(bundleId).log();
+            return null;
+        }
+        final BundleContext bundleContext = bundle.getBundleContext();
+        if (bundleContext == null) {
+            logger.atWarn().msg("Bundle '{}' does not have an active BundleContext").arg(bundleId).log();
+            return null;
+        }
+        final File dataFile = bundleContext.getDataFile(fileName);
+        if (dataFile == null || !dataFile.exists() || !dataFile.isFile()) {
+            return null;
+        }
+        return IO.collect(dataFile);
     }
 
     public static XBundleDTO toDTO(final Bundle bundle, final BundleStartTimeCalculator bundleStartTimeCalculator) {

--- a/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
+++ b/com.osgifx.console.agent/src/main/java/com/osgifx/console/agent/provider/AgentServer.java
@@ -155,6 +155,8 @@ import aQute.lib.converter.TypeReference;
 
 public final class AgentServer implements Agent, Closeable {
 
+    private static final String LOG_FILE = "osgifx_logs.bin";
+
     public enum RpcType {
         MQTT_RPC,
         SOCKET_RPC
@@ -194,10 +196,8 @@ public final class AgentServer implements Agent, Closeable {
         if (Boolean.getBoolean(AGENT_AUTO_START_LOG_CAPTURE_KEY)) {
             // Restore persistence
             try {
-                if (getContext() != null) { // Might be null if DI not ready?
-                    // Actually BundleContext is needed for dataFile.
-                    // Assuming DI has it if Activator started us.
-                    logBuffer.fromDisk(getContext().getDataFile("osgifx_logs.bin"));
+                if (getContext() != null) {
+                    logBuffer.fromDisk(getContext().getDataFile(LOG_FILE));
                 }
             } catch (Exception e) {
                 // Ignore
@@ -335,6 +335,11 @@ public final class AgentServer implements Agent, Closeable {
             revisions.add(bwd);
         }
         return revisions;
+    }
+
+    @Override
+    public String getBundleDataFile(final long id, final String fileName) throws Exception {
+        return di.getInstance(XBundleAdmin.class).getDataFile(id, fileName);
     }
 
     @Override
@@ -587,7 +592,7 @@ public final class AgentServer implements Agent, Closeable {
             cleanup();
             // Snapshot logs to disk on close
             if (getContext() != null) {
-                logBuffer.toDisk(getContext().getDataFile("osgifx_logs.bin"));
+                logBuffer.toDisk(getContext().getDataFile(LOG_FILE));
             }
 
             if (logReaderTracker != null) {
@@ -628,7 +633,7 @@ public final class AgentServer implements Agent, Closeable {
         if (osgiLogListenerCloser == null) {
             // Try to restore logs from previous run (if not done in constructor)
             try {
-                logBuffer.fromDisk(getContext().getDataFile("osgifx_logs.bin"));
+                logBuffer.fromDisk(getContext().getDataFile(LOG_FILE));
             } catch (Exception e) {
                 // Ignore if file doesn't exist or corrupted
             }

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/GetBundleDataFileTool.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/tool/GetBundleDataFileTool.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.mcp.tool;
+
+import static org.osgi.service.component.annotations.ReferenceCardinality.OPTIONAL;
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.eclipse.fx.core.log.FluentLogger;
+import org.eclipse.fx.core.log.LoggerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.osgifx.console.mcp.McpTool;
+import com.osgifx.console.mcp.McpToolSchema;
+import com.osgifx.console.propertytypes.McpToolDef;
+import com.osgifx.console.supervisor.Supervisor;
+
+@Component(service = McpTool.class)
+@McpToolDef(name = "get_bundle_data_file", description = "Retrieves the content of a file from a bundle's persistent storage area")
+public class GetBundleDataFileTool implements McpTool {
+
+    @Reference(cardinality = OPTIONAL, policyOption = GREEDY)
+    private volatile Supervisor supervisor;
+    @Reference
+    private LoggerFactory       factory;
+    private FluentLogger        logger;
+
+    @Activate
+    void activate() {
+        logger = FluentLogger.of(factory.createLogger(getClass().getName()));
+    }
+
+    @Override
+    public Map<String, Object> inputSchema() {
+        return McpToolSchema.builder().arg("bundleId", "integer", "The ID of the bundle")
+                .arg("fileName", "string", "The name of the file to retrieve, relative to the bundle's data area")
+                .build();
+    }
+
+    @Override
+    public Object execute(final Map<String, Object> args) throws Exception {
+        logger.atInfo().log("Executing GetBundleDataFileTool");
+        final var agent = supervisor.getAgent();
+        if (agent == null) {
+            logger.atWarning().log("Agent is not connected");
+            return Collections.emptyMap();
+        }
+
+        final var bundleId = ((Number) args.get("bundleId")).longValue();
+        final var fileName = (String) args.get("fileName");
+
+        final var content = agent.getBundleDataFile(bundleId, fileName);
+        return content != null ? Map.of("content", content) : Map.of("error", "File not found");
+    }
+}

--- a/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
+++ b/com.osgifx.console.supervisor/src/main/java/com/osgifx/console/supervisor/snapshot/SnapshotAgent.java
@@ -120,6 +120,11 @@ public final class SnapshotAgent implements Agent {
     }
 
     @Override
+    public String getBundleDataFile(final long id, final String fileName) throws Exception {
+        return null;
+    }
+
+    @Override
     public boolean redirect(final int port) throws Exception {
         return false;
     }


### PR DESCRIPTION
Introduced a new API to access files from a bundle's persistent storage area. Implemented security checks to prevent path traversal during file retrieval. Exposed this functionality through a new MCP tool for external client integration. Refactored internal log file handling to use a centralized constant.

Fixes #887