### PR TITLE
Moved screenshot to MCP server documentation

### DIFF
--- a/HEADLESS_LAUNCH.md
+++ b/HEADLESS_LAUNCH.md
@@ -5,8 +5,6 @@
 > [!NOTE]
 > "Headless" in this context means "without the connection wizard UI", not necessarily without any UI at all. The main application window will still open after connection.
 
-![Headless Launch](screenshots/7.png)
-
 ## How to Use
 
 To use this feature, you need to provide a JSON configuration file via the `osgifx.config` system property when launching the application.

--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -2,6 +2,8 @@
 
 An [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server that connects LLMs (like Claude) to a running OSGi framework. This allows you to diagnose, monitor, and debug remote OSGi runtimes using natural language.
 
+![MCP Server](screenshots/7.png)
+
 ## Features
 
 * **🔍 Deep Diagnostics:** Inspect bundles, services, components (DS), and configurations.


### PR DESCRIPTION
Relocated the diagnostic screenshot from the headless launch guide to the MCP server documentation to ensure the visual aids matched the relevant feature descriptions.

Fixes #892