### PR TITLE
Centralized connection management and persistence

### DIFF
--- a/cnf/ext/launcher.bnd
+++ b/cnf/ext/launcher.bnd
@@ -1,6 +1,6 @@
 -runrepos                       =         Workspace, Runtime, e(fx)clipse, Local
 -runfw                          =         org.eclipse.osgi;version=latest
--runkeep                        =         ${is;${driver};gradle}
+-runkeep                        =         false
 -runtrace                       =         true
 -runee                          =         JavaSE-25
 -runsystemcapabilities          =         ${native_capability},\
@@ -14,7 +14,8 @@
                                           bnd.identity;id='com.osgifx.console.api',\
                                           bnd.identity;id='org.osgi.service.messaging'
 current.directory               =         .
-storage.directory               =         ${current.directory}/.osgifx-ws
+osgifx.directory                =         ${current.directory}/.osgifx-ws
+storage.directory               =         ${osgifx.directory}/storage
 
 -runproperties.storage          =         launch.storage.dir=${storage.directory},\
                                           org.osgi.framework.storage=${storage.directory}

--- a/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/FxConstants.java
+++ b/com.osgifx.console.api/src/main/java/com/osgifx/console/constants/FxConstants.java
@@ -28,6 +28,9 @@ public final class FxConstants {
         throw new IllegalAccessError("Cannot be instantiated");
     }
 
+    /** System property key containing the workspace location */
+    public static final String WORKSPACE_PROPERTY = "osgifx.ws";
+
     /** Path to the root FXML file used in the application. */
     public static final String ROOT_FXML = "/fxml/tab-content.fxml";
 

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/MqttConnectionPreferenceHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/MqttConnectionPreferenceHandler.java
@@ -15,7 +15,6 @@
  ******************************************************************************/
 package com.osgifx.console.application.handler;
 
-import java.util.List;
 import java.util.stream.IntStream;
 
 import javax.annotation.PostConstruct;
@@ -26,15 +25,11 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.fx.core.log.FluentLogger;
 import org.eclipse.fx.core.log.Log;
-import org.eclipse.fx.core.preferences.Preference;
-import org.eclipse.fx.core.preferences.Value;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.osgifx.console.application.dialog.MqttConnectionSettingDTO;
+import com.osgifx.console.application.preference.ConnectionManager;
 import com.osgifx.console.application.preference.ConnectionsProvider;
 import com.osgifx.console.application.preference.CredentialManager;
 
@@ -44,16 +39,15 @@ public final class MqttConnectionPreferenceHandler {
     @Inject
     private FluentLogger        logger;
     @Inject
-    @Preference(nodePath = "osgi.fx.connections", key = "mqtt.settings", defaultValue = "")
-    private Value<String>       settings;
-    @Inject
     private ConnectionsProvider connectionsProvider;
     @Inject
     private CredentialManager   credentialManager;
+    @Inject
+    private ConnectionManager   connectionManager;
 
     @PostConstruct
     public void init() {
-        connectionsProvider.addMqttConnections(getStoredValues());
+        connectionsProvider.addMqttConnections(connectionManager.loadMqttConnections());
     }
 
     @Execute
@@ -73,8 +67,7 @@ public final class MqttConnectionPreferenceHandler {
                         @Named("subTopic") @Optional final String subTopic,
                         @Named("lwtTopic") @Optional final String lwtTopic) {
 
-        final var gson                     = new Gson();
-        final var connections              = getStoredValues();
+        final var connections              = connectionManager.loadMqttConnections();
         final var dtRequiresAuthentication = Boolean.parseBoolean(requiresAuthentication);
         final var dtSavePassword           = Boolean.parseBoolean(savePassword);
         final var dto                      = new MqttConnectionSettingDTO(id, name, clientId, server,
@@ -117,18 +110,7 @@ public final class MqttConnectionPreferenceHandler {
         } else {
             logger.atWarning().log("Cannot execute command with type '%s'", type);
         }
-        settings.publish(gson.toJson(connections));
-    }
-
-    private List<MqttConnectionSettingDTO> getStoredValues() {
-        final var                      gson        = new Gson();
-        List<MqttConnectionSettingDTO> connections = gson.fromJson(settings.getValue(),
-                new TypeToken<List<MqttConnectionSettingDTO>>() {
-                                                           }.getType());
-        if (connections == null) {
-            connections = Lists.newArrayList();
-        }
-        return connections;
+        connectionManager.saveMqttConnections(connections);
     }
 
 }

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/SocketConnectionPreferenceHandler.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/handler/SocketConnectionPreferenceHandler.java
@@ -15,7 +15,6 @@
  ******************************************************************************/
 package com.osgifx.console.application.handler;
 
-import java.util.List;
 import java.util.stream.IntStream;
 
 import javax.annotation.PostConstruct;
@@ -26,15 +25,11 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.fx.core.log.FluentLogger;
 import org.eclipse.fx.core.log.Log;
-import org.eclipse.fx.core.preferences.Preference;
-import org.eclipse.fx.core.preferences.Value;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.osgifx.console.application.dialog.SocketConnectionSettingDTO;
+import com.osgifx.console.application.preference.ConnectionManager;
 import com.osgifx.console.application.preference.ConnectionsProvider;
 import com.osgifx.console.application.preference.CredentialManager;
 
@@ -44,16 +39,15 @@ public final class SocketConnectionPreferenceHandler {
     @Inject
     private FluentLogger        logger;
     @Inject
-    @Preference(nodePath = "osgi.fx.connections", key = "socket.settings", defaultValue = "")
-    private Value<String>       settings;
-    @Inject
     private ConnectionsProvider connectionsProvider;
     @Inject
     private CredentialManager   credentialManager;
+    @Inject
+    private ConnectionManager   connectionManager;
 
     @PostConstruct
     public void init() {
-        connectionsProvider.addSocketConnections(getStoredValues());
+        connectionsProvider.addSocketConnections(connectionManager.loadSocketConnections());
     }
 
     @Execute
@@ -69,8 +63,7 @@ public final class SocketConnectionPreferenceHandler {
                         @Named("requiresAuthentication") @Optional final String requiresAuthentication,
                         @Named("savePassword") @Optional final String savePassword) {
 
-        final var gson                     = new Gson();
-        final var connections              = getStoredValues();
+        final var connections              = connectionManager.loadSocketConnections();
         final var dtRequiresAuthentication = Boolean.parseBoolean(requiresAuthentication);
         final var dtSavePassword           = Boolean.parseBoolean(savePassword);
         final var dto                      = new SocketConnectionSettingDTO(id, name, host, Ints.tryParse(port),
@@ -123,18 +116,7 @@ public final class SocketConnectionPreferenceHandler {
         } else {
             logger.atWarning().log("Cannot execute command with type '%s'", type);
         }
-        settings.publish(gson.toJson(connections));
-    }
-
-    private List<SocketConnectionSettingDTO> getStoredValues() {
-        final var                        gson        = new Gson();
-        List<SocketConnectionSettingDTO> connections = gson.fromJson(settings.getValue(),
-                new TypeToken<List<SocketConnectionSettingDTO>>() {
-                                                             }.getType());
-        if (connections == null) {
-            connections = Lists.newArrayList();
-        }
-        return connections;
+        connectionManager.saveSocketConnections(connections);
     }
 
 }

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/ConnectionManager.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/ConnectionManager.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.application.preference;
+
+import static com.osgifx.console.constants.FxConstants.WORKSPACE_PROPERTY;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.eclipse.fx.core.log.FluentLogger;
+import org.eclipse.fx.core.log.LoggerFactory;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.osgifx.console.application.dialog.MqttConnectionSettingDTO;
+import com.osgifx.console.application.dialog.SocketConnectionSettingDTO;
+
+/**
+ * Manages persistence of socket and MQTT connection configurations to a JSON
+ * file ({@code connections.json}) located in the workspace directory identified
+ * by the {@code osgifx.ws} system property.
+ *
+ * <p>
+ * Passwords are <em>not</em> persisted here; they remain handled by
+ * {@link CredentialManager} in the encrypted {@code credentials.json} file.
+ * </p>
+ */
+@Component(service = ConnectionManager.class)
+public final class ConnectionManager {
+
+    private static final Path CONNECTIONS_FILE = Paths.get(System.getProperty(WORKSPACE_PROPERTY), "connections.json");
+
+    @Reference
+    private LoggerFactory factory;
+    private FluentLogger  logger;
+
+    @Activate
+    void activate() {
+        logger = FluentLogger.of(factory.createLogger(getClass().getName()));
+        logger.atInfo().log("ConnectionManager initialized - connections file: %s", CONNECTIONS_FILE);
+    }
+
+    /**
+     * Saves the given socket connections to the {@code connections.json} file,
+     * preserving any existing MQTT connections already stored in the file.
+     *
+     * @param socketConnections the socket connections to persist; must not be
+     *            {@code null}
+     */
+    public void saveSocketConnections(final List<SocketConnectionSettingDTO> socketConnections) {
+        try {
+            final var dto = loadConnectionsDTO();
+            dto.socketConnections = new ArrayList<>(socketConnections);
+            persist(dto);
+        } catch (final Exception e) {
+            logger.atWarning().withException(e).log("Failed to save socket connections");
+        }
+    }
+
+    /**
+     * Saves the given MQTT connections to the {@code connections.json} file,
+     * preserving any existing socket connections already stored in the file.
+     *
+     * @param mqttConnections the MQTT connections to persist; must not be
+     *            {@code null}
+     */
+    public void saveMqttConnections(final List<MqttConnectionSettingDTO> mqttConnections) {
+        try {
+            final var dto = loadConnectionsDTO();
+            dto.mqttConnections = new ArrayList<>(mqttConnections);
+            persist(dto);
+        } catch (final Exception e) {
+            logger.atWarning().withException(e).log("Failed to save MQTT connections");
+        }
+    }
+
+    /**
+     * Loads and returns the socket connections from the {@code connections.json}
+     * file. Returns an empty list if the file does not exist or is corrupt.
+     *
+     * @return mutable list of {@link SocketConnectionSettingDTO}; never
+     *         {@code null}
+     */
+    public List<SocketConnectionSettingDTO> loadSocketConnections() {
+        final var dto = loadConnectionsDTO();
+        return dto.socketConnections != null ? dto.socketConnections : new ArrayList<>();
+    }
+
+    /**
+     * Loads and returns the MQTT connections from the {@code connections.json}
+     * file. Returns an empty list if the file does not exist or is corrupt.
+     *
+     * @return mutable list of {@link MqttConnectionSettingDTO}; never {@code null}
+     */
+    public List<MqttConnectionSettingDTO> loadMqttConnections() {
+        final var dto = loadConnectionsDTO();
+        return dto.mqttConnections != null ? dto.mqttConnections : new ArrayList<>();
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private ConnectionsDTO loadConnectionsDTO() {
+        if (!Files.exists(CONNECTIONS_FILE)) {
+            return new ConnectionsDTO();
+        }
+        try (var reader = Files.newBufferedReader(CONNECTIONS_FILE, StandardCharsets.UTF_8)) {
+            final var dto = createGSON().get().fromJson(reader, ConnectionsDTO.class);
+            return dto != null ? dto : new ConnectionsDTO();
+        } catch (final Exception e) {
+            logger.atWarning().withException(e).log("Failed to read connections file - returning empty");
+            return new ConnectionsDTO();
+        }
+    }
+
+    private void persist(final ConnectionsDTO dto) throws Exception {
+        Files.createDirectories(CONNECTIONS_FILE.getParent());
+        try (var writer = Files.newBufferedWriter(CONNECTIONS_FILE, StandardCharsets.UTF_8)) {
+            createGSON().get().toJson(dto, writer);
+        }
+        logger.atInfo().log("Connections persisted to %s", CONNECTIONS_FILE);
+    }
+
+    /**
+     * Internal wrapper DTO representing the full contents of
+     * {@code connections.json}.
+     */
+    private static final class ConnectionsDTO {
+        List<SocketConnectionSettingDTO> socketConnections = new ArrayList<>();
+        List<MqttConnectionSettingDTO>   mqttConnections   = new ArrayList<>();
+    }
+
+    private Supplier<Gson> createGSON() {
+        return () -> new GsonBuilder().setPrettyPrinting().create();
+    }
+
+}

--- a/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/CredentialManager.java
+++ b/com.osgifx.console.application/src/main/java/com/osgifx/console/application/preference/CredentialManager.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.osgifx.console.application.preference;
 
+import static com.osgifx.console.constants.FxConstants.WORKSPACE_PROPERTY;
 import static javax.crypto.Cipher.DECRYPT_MODE;
 import static javax.crypto.Cipher.ENCRYPT_MODE;
 
@@ -27,6 +28,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -38,14 +40,14 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 @Component(service = CredentialManager.class)
 public final class CredentialManager {
 
     private static final String ALGORITHM       = "AES";
-    private static final Path   CREDENTIAL_FILE = Paths.get(System.getProperty("user.dir"), ".osgifx-ws",
-            "credentials.json");
+    private static final Path   CREDENTIAL_FILE = Paths.get(System.getProperty(WORKSPACE_PROPERTY), "credentials.json");
 
     @Reference
     private LoggerFactory factory;
@@ -143,7 +145,7 @@ public final class CredentialManager {
         try (var reader = Files.newBufferedReader(CREDENTIAL_FILE, StandardCharsets.UTF_8)) {
             final var                 type = new TypeToken<ConcurrentHashMap<String, String>>() {
                                            }.getType();
-            final Map<String, String> map  = new Gson().fromJson(reader, type);
+            final Map<String, String> map  = createGSON().get().fromJson(reader, type);
             return map == null ? new ConcurrentHashMap<>() : map;
         } catch (final Exception e) {
             logger.atWarning().withException(e).log("Failed to read credentials file");
@@ -154,8 +156,11 @@ public final class CredentialManager {
     private void saveCredentialsMap(final Map<String, String> map) throws Exception {
         Files.createDirectories(CREDENTIAL_FILE.getParent());
         try (var writer = Files.newBufferedWriter(CREDENTIAL_FILE, StandardCharsets.UTF_8)) {
-            new Gson().toJson(map, writer);
+            createGSON().get().toJson(map, writer);
         }
     }
 
+    private Supplier<Gson> createGSON() {
+        return () -> new GsonBuilder().setPrettyPrinting().create();
+    }
 }

--- a/com.osgifx.console.product/osgifx.bndrun
+++ b/com.osgifx.console.product/osgifx.bndrun
@@ -36,7 +36,8 @@ startlevels                       :   com.osgifx.console.agent;startlevel=1,\
 
 -runproperties.product            :   eclipse.product=com.osgifx.console.application.product
 -runproperties.name               :   launch.name=OSGi.fx
--runproperties.logging            :   org.apache.sling.commons.log.file=${storage.directory}/logs/fx.log,\
+-runproperties.workspace          :   osgifx.ws=${osgifx.directory}
+-runproperties.logging            :   org.apache.sling.commons.log.file=${osgifx.directory}/logs/fx.log,\
                                       org.apache.sling.commons.log.pattern="{0,date,yyyy-MM-dd  HH:mm:ss.SSSXXX}     {4}     [{2}]  [{3}]  {5}"
 
 # the following configuration is used to ensure that MQTT client will not be automatically enabled


### PR DESCRIPTION
Introduced a dedicated ConnectionManager to handle the persistence of socket and MQTT connections in a JSON file. Moved connection storage from Eclipse preferences to the file system and standardized the workspace location using a new system property.

Closed #901