### PR TITLE
Prevented redundant initialization of FXML controllers

### DIFF
--- a/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
+++ b/com.osgifx.console.ui.bundles/src/main/java/com/osgifx/console/ui/bundles/BundlesFxController.java
@@ -119,6 +119,7 @@ public final class BundlesFxController {
 
     private FilteredList<XBundleDTO>         filteredList;
     private TableRowDataFeatures<XBundleDTO> previouslyExpanded;
+    private boolean                          isInitialized;
 
     @FXML
     public void initialize() {
@@ -129,8 +130,11 @@ public final class BundlesFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             updateButtonStates();
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {

--- a/com.osgifx.console.ui.cdi/src/main/java/com/osgifx/console/ui/cdi/CdiFxController.java
+++ b/com.osgifx.console.ui.cdi/src/main/java/com/osgifx/console/ui/cdi/CdiFxController.java
@@ -64,6 +64,7 @@ public final class CdiFxController {
     @Inject
     private ThreadSynchronize                      threadSync;
     private TableRowDataFeatures<XCdiContainerDTO> previouslyExpanded;
+    private boolean                                isInitialized;
 
     @FXML
     public void initialize() {
@@ -76,8 +77,11 @@ public final class CdiFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentDetailsFxController.java
@@ -141,6 +141,7 @@ public final class ComponentDetailsFxController {
     private XComponentDTO                                 selectedComponent;
     private TableRowDataFeatures<XReferenceDTO>           previouslyExpanded;
     private AtomicBoolean                                 areReferenceTableNodesLoader;
+    private boolean                                       isInitialized;
 
     @FXML
     public void initialize() {
@@ -191,16 +192,19 @@ public final class ComponentDetailsFxController {
         unboundServicesTable.setItems(FXCollections.observableArrayList(component.unsatisfiedReferences));
 
         createReferenceExpandedTable(component);
-        applyTableFilters();
+        if (!isInitialized) {
+            applyTableFilters();
 
-        Fx.addContextMenuToCopyContent(pidsList);
-        Fx.addContextMenuToCopyContent(interfacesList);
-        Fx.addContextMenuToCopyContent(propertiesTable);
-        Fx.addContextMenuToCopyContent(boundServicesTable);
-        Fx.addContextMenuToCopyContent(unboundServicesTable);
+            Fx.addContextMenuToCopyContent(pidsList);
+            Fx.addContextMenuToCopyContent(interfacesList);
+            Fx.addContextMenuToCopyContent(propertiesTable);
+            Fx.addContextMenuToCopyContent(boundServicesTable);
+            Fx.addContextMenuToCopyContent(unboundServicesTable);
 
-        Fx.disableSelectionModel(referencesTable);
-        referencesTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_ALL_COLUMNS);
+            Fx.disableSelectionModel(referencesTable);
+            referencesTable.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY_ALL_COLUMNS);
+            isInitialized = true;
+        }
     }
 
     private void initConditionalComponents(final XComponentDTO component) {

--- a/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
+++ b/com.osgifx.console.ui.components/src/main/java/com/osgifx/console/ui/components/ComponentsFxController.java
@@ -74,6 +74,7 @@ public final class ComponentsFxController {
     private ThreadSynchronize                   threadSync;
     private FilteredList<XComponentDTO>         filteredList;
     private TableRowDataFeatures<XComponentDTO> previouslyExpanded;
+    private boolean                             isInitialized;
 
     @FXML
     public void initialize() {
@@ -86,8 +87,11 @@ public final class ComponentsFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
+++ b/com.osgifx.console.ui.configurations/src/main/java/com/osgifx/console/ui/configurations/ConfigurationsFxController.java
@@ -98,6 +98,7 @@ public final class ConfigurationsFxController {
 
     private FilteredList<XConfigurationDTO>         filteredList;
     private TableRowDataFeatures<XConfigurationDTO> previouslyExpanded;
+    private boolean                                 isInitialized;
 
     @FXML
     public void initialize() {
@@ -113,8 +114,11 @@ public final class ConfigurationsFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             updateButtonStates();
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {

--- a/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxController.java
+++ b/com.osgifx.console.ui.events/src/main/java/com/osgifx/console/ui/events/EventsFxController.java
@@ -129,6 +129,7 @@ public final class EventsFxController {
     private final BooleanSupplier           isReceivingEvent        = () -> Boolean.getBoolean("is_receiving_event");
     private final Consumer<Boolean>         isReceivingEventUpdater = flag -> System.setProperty("is_receiving_event",
             String.valueOf(flag));
+    private boolean                         isInitialized;
 
     @FXML
     public void initialize() {
@@ -139,8 +140,11 @@ public final class EventsFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             initButtonIcons();
             updateButtonStates();
             logger.atDebug().log("FXML controller has been initialized");

--- a/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorPane.java
+++ b/com.osgifx.console.ui.heap/src/main/java/com/osgifx/console/ui/heap/HeapMonitorPane.java
@@ -16,6 +16,7 @@
 package com.osgifx.console.ui.heap;
 
 import static com.osgifx.console.event.topics.DataRetrievedEventTopics.DATA_RETRIEVED_CAPABILITIES_TOPIC;
+
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;

--- a/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
+++ b/com.osgifx.console.ui.http/src/main/java/com/osgifx/console/ui/http/HttpFxController.java
@@ -64,6 +64,7 @@ public final class HttpFxController {
     @Inject
     private ThreadSynchronize                       threadSync;
     private TableRowDataFeatures<XHttpComponentDTO> previouslyExpanded;
+    private boolean                                 isInitialized;
 
     @FXML
     public void initialize() {
@@ -76,8 +77,11 @@ public final class HttpFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.jaxrs/src/main/java/com/osgifx/console/ui/jaxrs/JaxRsFxController.java
+++ b/com.osgifx.console.ui.jaxrs/src/main/java/com/osgifx/console/ui/jaxrs/JaxRsFxController.java
@@ -64,6 +64,7 @@ public final class JaxRsFxController {
     @Inject
     private ThreadSynchronize                        threadSync;
     private TableRowDataFeatures<XJaxRsComponentDTO> previouslyExpanded;
+    private boolean                                  isInitialized;
 
     @FXML
     public void initialize() {
@@ -76,8 +77,11 @@ public final class JaxRsFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
+++ b/com.osgifx.console.ui.leaks/src/main/java/com/osgifx/console/ui/leaks/LeaksFxController.java
@@ -58,6 +58,7 @@ public final class LeaksFxController {
     private DataProvider                     dataProvider;
     @Inject
     private ThreadSynchronize                threadSync;
+    private boolean                          isInitialized;
 
     @FXML
     public void initialize() {
@@ -66,8 +67,11 @@ public final class LeaksFxController {
             return;
         }
         try {
-            initCells();
-            Fx.addContextMenuToCopyContent(table);
+            if (!isInitialized) {
+                initCells();
+                Fx.addContextMenuToCopyContent(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogConfigurationsFxController.java
@@ -65,6 +65,7 @@ public final class LogConfigurationsFxController {
     @Inject
     private ThreadSynchronize                             threadSync;
     private TableRowDataFeatures<XBundleLoggerContextDTO> previouslyExpanded;
+    private boolean                                       isInitialized;
 
     @FXML
     public void initialize() {
@@ -77,8 +78,11 @@ public final class LogConfigurationsFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsViewFxController.java
+++ b/com.osgifx.console.ui.logs/src/main/java/com/osgifx/console/ui/logs/LogsViewFxController.java
@@ -63,6 +63,7 @@ public final class LogsViewFxController {
     @Inject
     private ThreadSynchronize                  threadSync;
     private TableRowDataFeatures<XLogEntryDTO> previouslyExpanded;
+    private boolean                            isInitialized;
 
     @FXML
     public void initialize() {
@@ -71,8 +72,11 @@ public final class LogsViewFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.mcp/src/main/java/com/osgifx/console/ui/mcp/McpFxController.java
+++ b/com.osgifx.console.ui.mcp/src/main/java/com/osgifx/console/ui/mcp/McpFxController.java
@@ -113,6 +113,7 @@ public final class McpFxController {
     private final Gson                       gson  = new GsonBuilder().setPrettyPrinting().create();
     private TableRowDataFeatures<McpToolDTO> previouslyExpandedTool;
     private TableRowDataFeatures<McpLogDTO>  previouslyExpandedLog;
+    private boolean                          isInitialized;
 
     @FXML
     public void initialize() {
@@ -127,25 +128,28 @@ public final class McpFxController {
             return;
         }
         try {
-            if (mcpDataProvider == null) {
-                actionButton.setDisable(true);
-                refreshLogsButton.setDisable(true);
-                clearLogsButton.setDisable(true);
-                statusLabel.setText("Status: UNAVAILABLE");
-                Fx.showErrorNotification("Model Context Protocol", "MCP data provider service is unavailable");
-                return;
+            if (!isInitialized) {
+                if (mcpDataProvider == null) {
+                    actionButton.setDisable(true);
+                    refreshLogsButton.setDisable(true);
+                    clearLogsButton.setDisable(true);
+                    statusLabel.setText("Status: UNAVAILABLE");
+                    Fx.showErrorNotification("Model Context Protocol", "MCP data provider service is unavailable");
+                    return;
+                }
+                if (fxMcpServer == null) {
+                    actionButton.setDisable(true);
+                    refreshLogsButton.setDisable(true);
+                    clearLogsButton.setDisable(true);
+                    statusLabel.setText("Status: UNAVAILABLE");
+                    Fx.showErrorNotification("Model Context Protocol", "MCP server is unavailable");
+                    return;
+                }
+                initToolsTable();
+                initLogsTable();
+                Fx.disableSelectionModel(toolsTable, logsTable);
+                isInitialized = true;
             }
-            if (fxMcpServer == null) {
-                actionButton.setDisable(true);
-                refreshLogsButton.setDisable(true);
-                clearLogsButton.setDisable(true);
-                statusLabel.setText("Status: UNAVAILABLE");
-                Fx.showErrorNotification("Model Context Protocol", "MCP server is unavailable");
-                return;
-            }
-            initToolsTable();
-            initLogsTable();
-            Fx.disableSelectionModel(toolsTable, logsTable);
             updateTools();
             updateLogs();
             updateStatus();

--- a/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
+++ b/com.osgifx.console.ui.packages/src/main/java/com/osgifx/console/ui/packages/PackagesFxController.java
@@ -69,6 +69,7 @@ public final class PackagesFxController {
     private ThreadSynchronize                threadSync;
     private FilteredList<PackageDTO>         filteredList;
     private TableRowDataFeatures<PackageDTO> previouslyExpanded;
+    private boolean                          isInitialized;
 
     @FXML
     public void initialize() {
@@ -77,8 +78,11 @@ public final class PackagesFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
+++ b/com.osgifx.console.ui.roles/src/main/java/com/osgifx/console/ui/roles/RolesFxController.java
@@ -90,6 +90,7 @@ public final class RolesFxController {
     private Button              addRoleButton;
 
     private TableRowDataFeatures<XRoleDTO> previouslyExpanded;
+    private boolean                        isInitialized;
 
     @FXML
     public void initialize() {
@@ -105,8 +106,11 @@ public final class RolesFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             updateButtonStates();
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {

--- a/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
+++ b/com.osgifx.console.ui.services/src/main/java/com/osgifx/console/ui/services/ServicesFxController.java
@@ -71,6 +71,7 @@ public final class ServicesFxController {
     private ThreadSynchronize                 threadSync;
     private FilteredList<XServiceDTO>         filteredList;
     private TableRowDataFeatures<XServiceDTO> previouslyExpanded;
+    private boolean                           isInitialized;
 
     @FXML
     public void initialize() {
@@ -79,8 +80,11 @@ public final class ServicesFxController {
             return;
         }
         try {
-            createControls();
-            Fx.disableSelectionModel(table);
+            if (!isInitialized) {
+                createControls();
+                Fx.disableSelectionModel(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");

--- a/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
+++ b/com.osgifx.console.ui.threads/src/main/java/com/osgifx/console/ui/threads/ThreadsFxController.java
@@ -63,6 +63,7 @@ public final class ThreadsFxController {
     private DataProvider                    dataProvider;
     @Inject
     private ThreadSynchronize               threadSync;
+    private boolean                         isInitialized;
 
     @FXML
     public void initialize() {
@@ -71,8 +72,11 @@ public final class ThreadsFxController {
             return;
         }
         try {
-            initCells();
-            Fx.addContextMenuToCopyContent(table);
+            if (!isInitialized) {
+                initCells();
+                Fx.addContextMenuToCopyContent(table);
+                isInitialized = true;
+            }
             logger.atDebug().log("FXML controller has been initialized");
         } catch (final Exception e) {
             logger.atError().withException(e).log("FXML controller could not be initialized");


### PR DESCRIPTION
Introduced an initialization flag across various FXML controllers to ensure that UI setup logic and listener registration are only performed once, avoiding duplicate control creation and configuration.

Fixed #919