### PR TITLE
Applied search filter during Conditions UI initialization

### DIFF
--- a/com.osgifx.console.ui.conditions/src/main/java/com/osgifx/console/ui/conditions/ConditionsFxUI.java
+++ b/com.osgifx.console.ui.conditions/src/main/java/com/osgifx/console/ui/conditions/ConditionsFxUI.java
@@ -124,6 +124,10 @@ public final class ConditionsFxUI {
             @Override
             protected Void call() throws Exception {
                 tabContent = Fx.loadFXML(loader, context, ROOT_FXML);
+                final var controller = (ConditionsFxController) loader.getController();
+                if (searchFilter != null) {
+                    controller.onFilterUpdateEvent(searchFilter);
+                }
                 return null;
             }
 


### PR DESCRIPTION
Ensured that any existing search filter is propagated to the controller upon loading the FXML to maintain the filtered state.