### PR TITLE
Enhanced MCP server with traditional SSE support & protocol negotiation

### DIFF
--- a/MCP_SERVER.md
+++ b/MCP_SERVER.md
@@ -32,9 +32,25 @@ The MCP server is built into the **OSGi.fx** application.
 
 ### 3. Client Configuration (SSE)
 
-Configure your MCP client (e.g., Claude Desktop) to connect via Server-Sent Events (SSE).
+Configure your MCP client (e.g., Claude Desktop, Cursor, Windsurf) to connect via Server-Sent Events (SSE).
 
-**Example Configuration:**
+**Recommended Configuration (Traditional SSE):**
+Traditional SSE uses separate endpoints for the stream and messages, providing the best compatibility with most modern clients.
+
+```json
+{
+  "mcpServers": {
+    "osgifx": {
+      "serverUrl": "http://localhost:8080/sse",
+      "type": "sse",
+      "disabled": false
+    }
+  }
+}
+```
+
+**Alternative Configuration (Streamable HTTP):**
+This uses a single endpoint for both streaming and messages. Use this if your client explicitly supports Streamable HTTP.
 
 ```json
 {
@@ -47,6 +63,15 @@ Configure your MCP client (e.g., Claude Desktop) to connect via Server-Sent Even
   }
 }
 ```
+
+### 4. Protocol Compatibility
+
+The OSGi.fx MCP Server actively negotiates the Model Context Protocol version during initialization.
+
+*   **Primary Supported Version:** `2025-03-26` (Ensures seamless compatibility with modern AI clients).
+*   **Backward Compatibility:** `2024-11-05` is fully supported for older clients.
+
+Clients requesting unsupported versions will be offered `2025-03-26` as the fallback negotiated version.
 
 ## Available Tools
 

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpHttpServer.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/provider/McpHttpServer.java
@@ -21,6 +21,7 @@ import static org.osgi.service.component.annotations.ReferencePolicy.STATIC;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,6 +41,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import com.osgifx.console.mcp.FxMcpServer;
 import com.osgifx.console.mcp.provider.McpHttpServer.Configuration;
+import com.osgifx.console.mcp.server.McpProtocol;
 
 import io.fusionauth.http.HTTPMethod;
 import io.fusionauth.http.server.HTTPHandler;
@@ -109,17 +111,43 @@ public class McpHttpServer implements FxMcpServer {
             final String path = req.getPath();
             logger.atInfo().log("Incoming Request: %s %s", req.getMethod(), path);
 
-            // Streamable HTTP Endpoint (GET/POST /mcp)
+            // Streamable HTTP Endpoint (Legacy OSGi.fx implementation)
             if ("/mcp".equals(path) || path.startsWith("/mcp?")) {
-                // POST: Message Handling (Stateless)
                 if (HTTPMethod.POST == req.getMethod()) {
-                    handleMessage(req, res);
+                    handleMessage(req, res, req.getHeader("Mcp-Session-Id"));
                     return;
                 }
-
-                // GET: Optional SSE Streaming
                 if (HTTPMethod.GET == req.getMethod() && "text/event-stream".equals(req.getHeader("Accept"))) {
-                    handleSseConnection(req, res);
+                    handleSseConnection(req, res, false); // false = streamable HTTP mode
+                    return;
+                }
+            }
+
+            // Traditional SSE Endpoint (Expected by Claude Code, Cursor, etc.)
+            if ("/sse".equals(path) || path.startsWith("/sse?")) {
+                if (HTTPMethod.GET == req.getMethod() && "text/event-stream".equals(req.getHeader("Accept"))) {
+                    handleSseConnection(req, res, true); // true = traditional SSE mode
+                    return;
+                }
+            }
+
+            // Traditional Message Endpoint
+            if ("/messages".equals(path) || path.startsWith("/messages?")) {
+                if (HTTPMethod.POST == req.getMethod()) {
+                    // Extract session ID from query parameters
+                    final Map<String, List<String>> params = req.getURLParameters();
+                    String                          sessionId;
+                    if (params != null && params.containsKey("sessionId")) {
+                        final List<String> sessionIds = params.get("sessionId");
+                        sessionId = (sessionIds == null || sessionIds.isEmpty()) ? null : sessionIds.get(0);
+                        if (sessionId != null && sessionId.contains("[")) {
+                            // FusionAuth might wrap params in arrays depending on parsing
+                            sessionId = sessionId.replaceAll("[\\[\\]]", "");
+                        }
+                    } else {
+                        sessionId = null;
+                    }
+                    handleMessage(req, res, sessionId);
                     return;
                 }
             }
@@ -184,11 +212,11 @@ public class McpHttpServer implements FxMcpServer {
         });
     }
 
-    private void handleSseConnection(final HTTPRequest req, final HTTPResponse res) {
+    private void handleSseConnection(final HTTPRequest req, final HTTPResponse res, final boolean isTraditionalMode) {
         try {
             // Log Streamable HTTP headers for debugging/context
-            String sessionId   = req.getHeader("Mcp-Session-Id");
-            String lastEventId = req.getHeader("Last-Event-ID");
+            String       sessionId   = req.getHeader("Mcp-Session-Id");
+            final String lastEventId = req.getHeader("Last-Event-ID");
             logger.atDebug().log("SSE Connection Request - Session: %s, Last-Event-ID: %s", sessionId, lastEventId);
 
             // Standard SSE Headers
@@ -196,24 +224,34 @@ public class McpHttpServer implements FxMcpServer {
             res.setHeader("Cache-Control", "no-cache");
             res.setHeader("Connection", "keep-alive");
 
-            // Reflect Protocol Version if requested
-            String protocolVersion = req.getHeader("MCP-Protocol-Version");
-            if (protocolVersion != null) {
-                res.setHeader("MCP-Protocol-Version", protocolVersion);
+            // Negotiate Protocol Version at the transport level
+            final String requestedVersion = req.getHeader("MCP-Protocol-Version");
+            if (requestedVersion != null) {
+                final String negotiatedVersion = McpProtocol.negotiateVersion(requestedVersion);
+                res.setHeader("MCP-Protocol-Version", negotiatedVersion);
             }
 
             // Generate session ID if missing
             if (sessionId == null) {
                 sessionId = UUID.randomUUID().toString();
-                // Set session header before stream flush
+            }
+
+            // Streamable HTTP requires header reflection
+            if (!isTraditionalMode) {
                 res.setHeader("Mcp-Session-Id", sessionId);
             }
 
             res.setStatus(200);
             res.flush(); // Send headers
 
-            // In Streamable HTTP, we don't need to send the 'endpoint' handshake event.
-            // We just keep the connection open for any potential server-initiated notifications.
+            // Traditional SSE requires an endpoint event immediately
+            if (isTraditionalMode) {
+                final String endpointUri   = "/messages?sessionId=" + sessionId;
+                final String endpointEvent = "event: endpoint\ndata: " + endpointUri + "\n\n";
+                res.getOutputStream().write(endpointEvent.getBytes(StandardCharsets.UTF_8));
+                res.flush();
+                logger.atDebug().log("Emitted traditional SSE endpoint: %s", endpointUri);
+            }
 
             // Keep connection open by blocking
             final ConnectionContext ctx = new ConnectionContext();
@@ -238,16 +276,15 @@ public class McpHttpServer implements FxMcpServer {
         }
     }
 
-    private void handleMessage(final HTTPRequest req, final HTTPResponse res) {
+    private void handleMessage(final HTTPRequest req, final HTTPResponse res, String sessionId) {
         try {
             // Log session context
-            String sessionId = req.getHeader("Mcp-Session-Id");
             logger.atDebug().log("MCP Message - Session: %s", sessionId);
 
             // Read the JSON body
             final String body = new String(req.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
 
-            // Generate Session ID on initialize
+            // Generate Session ID on initialize if somehow missing
             if (sessionId == null && body.contains("\"method\":\"initialize\"")) {
                 sessionId = UUID.randomUUID().toString();
                 logger.atDebug().log("Generated new session ID for initialization: %s", sessionId);
@@ -265,10 +302,11 @@ public class McpHttpServer implements FxMcpServer {
                     res.setHeader("Mcp-Session-Id", sessionId);
                 }
 
-                // Reflect Protocol Version if requested
-                String protocolVersion = req.getHeader("MCP-Protocol-Version");
-                if (protocolVersion != null) {
-                    res.setHeader("MCP-Protocol-Version", protocolVersion);
+                // Negotiate Protocol Version at the transport level
+                final String requestedVersion = req.getHeader("MCP-Protocol-Version");
+                if (requestedVersion != null) {
+                    final String negotiatedVersion = McpProtocol.negotiateVersion(requestedVersion);
+                    res.setHeader("MCP-Protocol-Version", negotiatedVersion);
                 }
 
                 res.setStatus(200);

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/server/McpJsonRpcServer.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/server/McpJsonRpcServer.java
@@ -49,9 +49,6 @@ public class McpJsonRpcServer {
     private final List<McpLogEntry> logs  = new ArrayList<>();
     private static final int        LIMIT = 100;
 
-    // MCP Spec Version
-    private static final String LATEST_PROTOCOL_VERSION = "2024-11-05";
-
     public McpJsonRpcServer(final Gson gson) {
         this.gson = gson;
     }
@@ -173,12 +170,21 @@ public class McpJsonRpcServer {
     // --- Handlers ---
 
     private String handleInitialize(final JsonRpc.Request req) {
+        // Extract the client's requested version
+        String clientVersion = null;
+        if (req.params != null && req.params.containsKey("protocolVersion")) {
+            clientVersion = (String) req.params.get("protocolVersion");
+        }
+
+        // Negotiate the protocol version
+        final String negotiatedVersion = McpProtocol.negotiateVersion(clientVersion);
+
         // Declare capabilities: Tools only (no Resources/Prompts)
         final var capabilities = Map.of("tools", Map.of("listChanged", true), "resources", Map.of("listChanged", false),
                 "prompts", Map.of("listChanged", false));
 
-        final var result = Map.of("protocolVersion", LATEST_PROTOCOL_VERSION, "capabilities", capabilities,
-                "serverInfo", Map.of("name", "OSGi.fx", "version", "1.0.0"));
+        final var result = Map.of("protocolVersion", negotiatedVersion, "capabilities", capabilities, "serverInfo",
+                Map.of("name", "OSGi.fx", "version", "1.0.0"));
         return success(req.id, result);
     }
 

--- a/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/server/McpProtocol.java
+++ b/com.osgifx.console.mcp/src/main/java/com/osgifx/console/mcp/server/McpProtocol.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright 2021-2026 Amit Kumar Mondal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package com.osgifx.console.mcp.server;
+
+import java.util.List;
+
+public final class McpProtocol {
+
+    private McpProtocol() {
+    }
+
+    // Ordered from newest to oldest
+    public static final List<String> SUPPORTED_VERSIONS = List.of("2025-03-26", "2024-11-05");
+
+    /**
+     * Negotiates the protocol version.
+     * If the client's requested version is supported, it is returned.
+     * Otherwise, it falls back to the server's highest supported version.
+     */
+    public static String negotiateVersion(final String requestedVersion) {
+        if (requestedVersion != null && SUPPORTED_VERSIONS.contains(requestedVersion)) {
+            return requestedVersion;
+        }
+        return SUPPORTED_VERSIONS.get(0);
+    }
+}


### PR DESCRIPTION
Implemented traditional SSE endpoints (`/sse` and `/messages`) to improve compatibility with AI clients such as Claude Code and Cursor. Introduced a formal protocol negotiation mechanism to support multiple MCP versions, including the latest 2025-03-26 specification, and updated the documentation with the new configuration options.

Closes #942