### PR TITLE
Downgraded Mockito to version 4 for Java 8 compatibility

### DIFF
--- a/cnf/ext/testing.bnd
+++ b/cnf/ext/testing.bnd
@@ -1,4 +1,4 @@
-## JUnit 5 + Mockito 5 — auto-applied to all workspace projects
+## JUnit 5 + Mockito 4 (Java 8 compatible) — auto-applied to all workspace projects
 -tester: biz.aQute.tester.junit-platform
 testing.bundles : \
     junit-jupiter-api,\

--- a/cnf/maven/build.maven
+++ b/cnf/maven/build.maven
@@ -91,13 +91,13 @@ org.junit.vintage:junit-vintage-engine:5.9.1
 org.opentest4j:opentest4j:1.2.0
 org.apiguardian:apiguardian-api:1.1.2
 
-# Mockito
-org.mockito:mockito-core:5.14.2
-org.mockito:mockito-junit-jupiter:5.14.2
+# Mockito (4.x — last Java 8 compatible release)
+org.mockito:mockito-core:4.11.0
+org.mockito:mockito-junit-jupiter:4.11.0
 
 # Mockito transitive deps
-net.bytebuddy:byte-buddy:1.15.10
-net.bytebuddy:byte-buddy-agent:1.15.10
+net.bytebuddy:byte-buddy:1.12.19
+net.bytebuddy:byte-buddy-agent:1.12.19
 org.objenesis:objenesis:3.3
 # SLF4J
 org.slf4j:slf4j-api:1.7.36


### PR DESCRIPTION
Reverted Mockito and Byte Buddy to their last Java 8 compatible versions to maintain build support for older environments.